### PR TITLE
CD 과정에서 jar 파일에 접근하지 못하는 에러 해결

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -77,6 +77,6 @@ jobs:
           docker pull ${{ secrets.DOCKER_HUB_USERNAME }}/tokpik-be
           docker run -d \
           -p 8080:8080  \
-          -v /home/ubuntu/logs:/app \
+          -v /home/ubuntu/logs:/app/logs \
           --name tokpik-be \
           ${{ secrets.DOCKER_HUB_USERNAME }}/tokpik-be

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,5 +6,8 @@ COPY build/libs/*.jar tokpik_be.jar
 
 EXPOSE 8080
 
+# 로그 디렉토리 생성 및 권한 부여
+RUN mkdir -p /logs && chmod 755 /logs
+
 # 백그라운드에서 실행하고 로그를 파일에 저장
-CMD nohup java -jar -Dspring.profiles.active=dev tokpik_be.jar > application.log 2>&1
+CMD java -jar -Dspring.profiles.active=dev tokpik_be.jar > /logs/application.log 2>&1


### PR DESCRIPTION
## 작업 대상
<!-- 작업 대상을 설명 -->
- Dockerfile
- CD 스크립트

## 📄 작업 내용
<!-- 작업한 내용을 간단히 요약해주세요. -->
- CD 과정에서 jar 파일에 접근하지 못하는 에러 해결
- 컨테이너내 별도의 로그 파일 보관 디렉토리 정의
- 해당 디렉토리를 호스트 디렉토리에 마운트하도록 구성해 에러 해결

## 📎 레퍼런스
<!-- 작업 시 참고했던 문건의 URL을 남겨주세요 -->