### PR TITLE
access token refresh 기능 수정

### DIFF
--- a/src/main/java/org/example/tokpik_be/user/domain/User.java
+++ b/src/main/java/org/example/tokpik_be/user/domain/User.java
@@ -12,8 +12,6 @@ import java.util.Objects;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
-
 import org.example.tokpik_be.common.BaseTimeEntity;
 import org.example.tokpik_be.user.converter.GenderConverter;
 import org.example.tokpik_be.user.enums.Gender;
@@ -57,5 +55,10 @@ public class User extends BaseTimeEntity {
     public void updateProfile(LocalDate birth, Gender gender) {
         this.birth = birth;
         this.gender = gender;
+    }
+
+    public boolean notEqualRefreshToken(String refreshToken) {
+
+        return !this.refreshToken.equals(refreshToken);
     }
 }

--- a/src/main/java/org/example/tokpik_be/user/service/UserQueryService.java
+++ b/src/main/java/org/example/tokpik_be/user/service/UserQueryService.java
@@ -58,9 +58,4 @@ public class UserQueryService {
         return userRepository.findByEmail(email)
             .orElseThrow(() -> new GeneralException(UserException.USER_NOT_FOUND));
     }
-
-    public boolean notExistsById(long userId) {
-
-        return !userRepository.existsById(userId);
-    }
 }

--- a/src/main/java/org/example/tokpik_be/util/JwtUtil.java
+++ b/src/main/java/org/example/tokpik_be/util/JwtUtil.java
@@ -24,22 +24,22 @@ public class JwtUtil {
         this.parser = Jwts.parser().verifyWith(this.key).build();
     }
 
-    public String generateAccessToken(long userId) {
+    public String generateAccessToken(long userId, Date generatedAt) {
 
-        return generateUserJwt(userId, ACCESS_TOKEN_DURATION);
+        return generateUserJwt(userId, generatedAt, ACCESS_TOKEN_DURATION);
     }
 
-    public String generateRefreshToken(long userId) {
+    public String generateRefreshToken(long userId, Date generatedAt) {
 
-        return generateUserJwt(userId, REFRESH_TOKEN_DURATION);
+        return generateUserJwt(userId, generatedAt, REFRESH_TOKEN_DURATION);
     }
 
-    private String generateUserJwt(long userId, Duration duration) {
+    private String generateUserJwt(long userId, Date generatedAt, Duration duration) {
 
         return Jwts.builder()
             .signWith(key)
             .claim("userId", userId)
-            .expiration(new Date(duration.toMillis()))
+            .expiration(new Date(generatedAt.getTime() + duration.toMillis()))
             .compact();
     }
 

--- a/src/main/java/org/example/tokpik_be/util/JwtUtil.java
+++ b/src/main/java/org/example/tokpik_be/util/JwtUtil.java
@@ -24,22 +24,22 @@ public class JwtUtil {
         this.parser = Jwts.parser().verifyWith(this.key).build();
     }
 
-    public String generateAccessToken(long userId, Date generatedAt) {
+    public String generateAccessToken(long userId, Date generateAt) {
 
-        return generateUserJwt(userId, generatedAt, ACCESS_TOKEN_DURATION);
+        return generateUserJwt(userId, generateAt, ACCESS_TOKEN_DURATION);
     }
 
-    public String generateRefreshToken(long userId, Date generatedAt) {
+    public String generateRefreshToken(long userId, Date generateAt) {
 
-        return generateUserJwt(userId, generatedAt, REFRESH_TOKEN_DURATION);
+        return generateUserJwt(userId, generateAt, REFRESH_TOKEN_DURATION);
     }
 
-    private String generateUserJwt(long userId, Date generatedAt, Duration duration) {
+    private String generateUserJwt(long userId, Date generateAt, Duration duration) {
 
         return Jwts.builder()
             .signWith(key)
             .claim("userId", userId)
-            .expiration(new Date(generatedAt.getTime() + duration.toMillis()))
+            .expiration(new Date(generateAt.getTime() + duration.toMillis()))
             .compact();
     }
 


### PR DESCRIPTION
## 작업 대상
<!-- 작업 대상을 설명 -->
- access token refresh 로직

## 📄 작업 내용
<!-- 작업한 내용을 간단히 요약해주세요. -->
- 기존 로직은 사용자 refresh token을 확인하지 않는 잘못된 구조
- 사용자 refresh token과 요청된 refresh token을 비교하는 구문 추가
- JWT 생성시 expiration을 과거 시점으로 설정하는 잘못된 코드 수정
  - 생성 일자를 매개변수로 받아 테스트 용이하도록 변경

## 📎 레퍼런스
<!-- 작업 시 참고했던 문건의 URL을 남겨주세요 -->