### PR TITLE
대화 주제 조회(검색)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,6 +38,9 @@ dependencies {
     // swagger
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2'
 
+    // spring ai openai
+    implementation 'org.springframework.ai:spring-ai-openai-spring-boot-starter'
+
     // lombok
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/org/example/tokpik_be/config/OpenAiApiConfig.java
+++ b/src/main/java/org/example/tokpik_be/config/OpenAiApiConfig.java
@@ -1,0 +1,22 @@
+package org.example.tokpik_be.config;
+
+import org.springframework.ai.openai.OpenAiChatModel;
+import org.springframework.ai.openai.api.OpenAiApi;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class OpenAiApiConfig {
+
+    @Value("${OPEN_AI_API_KEY}")
+    private String apiKey;
+
+    @Bean
+    public OpenAiChatModel chatModel() {
+
+        OpenAiApi openAiApi = new OpenAiApi(apiKey);
+
+        return new OpenAiChatModel(openAiApi);
+    }
+}

--- a/src/main/java/org/example/tokpik_be/tag/domain/PlaceTag.java
+++ b/src/main/java/org/example/tokpik_be/tag/domain/PlaceTag.java
@@ -1,0 +1,30 @@
+package org.example.tokpik_be.tag.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.example.tokpik_be.common.BaseTimeEntity;
+
+@Table(name = "talk_place_tags")
+@Getter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PlaceTag extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String content;
+
+    public PlaceTag(String content) {
+        this.content = content;
+    }
+}

--- a/src/main/java/org/example/tokpik_be/tag/domain/TopicTag.java
+++ b/src/main/java/org/example/tokpik_be/tag/domain/TopicTag.java
@@ -1,8 +1,5 @@
 package org.example.tokpik_be.tag.domain;
 
-import org.example.tokpik_be.common.BaseTimeEntity;
-import org.springframework.data.jpa.domain.support.AuditingEntityListener;
-
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
@@ -12,6 +9,7 @@ import jakarta.persistence.Table;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import org.example.tokpik_be.common.BaseTimeEntity;
 
 @Table(name = "talk_topic_tags")
 @Getter
@@ -27,8 +25,7 @@ public class TopicTag extends BaseTimeEntity {
     @Column(nullable = false)
     private String content;
 
-    public TopicTag(Long id, String content) {
-        this.id = id;
+    public TopicTag(String content) {
         this.content = content;
     }
 }

--- a/src/main/java/org/example/tokpik_be/tag/entity/UserPlaceTag.java
+++ b/src/main/java/org/example/tokpik_be/tag/entity/UserPlaceTag.java
@@ -1,0 +1,36 @@
+package org.example.tokpik_be.tag.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.example.tokpik_be.common.BaseTimeEntity;
+import org.example.tokpik_be.tag.domain.PlaceTag;
+
+@Table(name = "user_place_tags")
+@Getter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class UserPlaceTag extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private long userId;
+
+    @ManyToOne
+    @JoinColumn(name = "talk_place_tag_id")
+    private PlaceTag placeTag;
+
+    public UserPlaceTag(long userId, PlaceTag placeTag) {
+        this.userId = userId;
+        this.placeTag = placeTag;
+    }
+}

--- a/src/main/java/org/example/tokpik_be/talk_topic/controller/TalkTopicController.java
+++ b/src/main/java/org/example/tokpik_be/talk_topic/controller/TalkTopicController.java
@@ -1,0 +1,32 @@
+package org.example.tokpik_be.talk_topic.controller;
+
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.example.tokpik_be.talk_topic.dto.request.TalkTopicSearchRequest;
+import org.example.tokpik_be.talk_topic.dto.response.TalkTopicSearchResponse;
+import org.example.tokpik_be.talk_topic.service.TalkTopicQueryService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestAttribute;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "대화 주제 API", description = "대화 주제 연관 API")
+@RestController
+@RequiredArgsConstructor
+public class TalkTopicController {
+
+    private final TalkTopicQueryService talkTopicQueryService;
+
+    @GetMapping("/topics")
+    public ResponseEntity<List<TalkTopicSearchResponse>> searchTalkTopics(
+        @RequestAttribute("userId") long userId,
+        @RequestBody TalkTopicSearchRequest request) {
+
+        List<TalkTopicSearchResponse> response = talkTopicQueryService
+            .searchTalkTopics(userId, request);
+
+        return ResponseEntity.ok().body(response);
+    }
+}

--- a/src/main/java/org/example/tokpik_be/talk_topic/domain/TalkPartner.java
+++ b/src/main/java/org/example/tokpik_be/talk_topic/domain/TalkPartner.java
@@ -1,0 +1,28 @@
+package org.example.tokpik_be.talk_topic.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Convert;
+import jakarta.persistence.Embeddable;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.example.tokpik_be.user.converter.GenderConverter;
+import org.example.tokpik_be.user.enums.Gender;
+
+@Getter
+@Embeddable
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class TalkPartner {
+
+    @Column(name = "partner_gender", nullable = false)
+    @Convert(converter = GenderConverter.class)
+    private Gender gender;
+
+    @Column(name = "partner_age_lower_bound", nullable = false)
+    private int ageLowerBound;
+
+    @Column(name = "partner_age_upper_bound", nullable = false)
+    private int ageUpperBound;
+}

--- a/src/main/java/org/example/tokpik_be/talk_topic/domain/TalkTopic.java
+++ b/src/main/java/org/example/tokpik_be/talk_topic/domain/TalkTopic.java
@@ -1,0 +1,62 @@
+package org.example.tokpik_be.talk_topic.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embedded;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.example.tokpik_be.common.BaseTimeEntity;
+import org.example.tokpik_be.tag.domain.PlaceTag;
+import org.example.tokpik_be.tag.domain.TopicTag;
+
+@Table(name = "talk_topics")
+@Getter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class TalkTopic extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String title;
+
+    @Column(nullable = false)
+    private String subtitle;
+
+    @Column(nullable = false)
+    private String situation;
+
+    @Embedded
+    private TalkPartner partner;
+
+    @OneToOne
+    @JoinColumn(name = "talk_topic_tag_id")
+    private TopicTag topicTag;
+
+    @OneToOne
+    @JoinColumn(name = "talk_place_tag_id")
+    private PlaceTag placeTag;
+
+    public TalkTopic(String title,
+        String subtitle,
+        String situation,
+        TalkPartner partner,
+        TopicTag topicTag,
+        PlaceTag placeTag) {
+        this.title = title;
+        this.subtitle = subtitle;
+        this.situation = situation;
+        this.partner = partner;
+        this.topicTag = topicTag;
+        this.placeTag = placeTag;
+    }
+}

--- a/src/main/java/org/example/tokpik_be/talk_topic/dto/request/TalkTopicSearchRequest.java
+++ b/src/main/java/org/example/tokpik_be/talk_topic/dto/request/TalkTopicSearchRequest.java
@@ -1,0 +1,29 @@
+package org.example.tokpik_be.talk_topic.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+
+public record TalkTopicSearchRequest(
+    @Schema(type = "boolean", description = "필터(검색 조건) 사용 여부", example = "true")
+    boolean includeFilterCondition,
+
+    @Schema(type = "string", description = "대화목적", example = "친목")
+    List<String> talkPurposes,
+
+    @Schema(type = "string", description = "대화상황", example = "첫만남")
+    List<String> talkSituations,
+
+    @Schema(type = "string", description = "대화분위기", example = "유익한 분위기")
+    List<String> talkMoods,
+
+    @Schema(type = "boolean", description = "대화상대 성별, 남=true/여=false", example = "true")
+    Boolean talkPartnerGender,
+
+    @Schema(type = "number", description = "대화상대 연령대 하한", example = "20")
+    Integer talkPartnerAgeLowerBound,
+
+    @Schema(type = "number", description = "대화상대 연령대 상한", example = "25")
+    Integer talkPartnerAgeUpperBound
+) {
+
+}

--- a/src/main/java/org/example/tokpik_be/talk_topic/dto/response/TalkTopicSearchResponse.java
+++ b/src/main/java/org/example/tokpik_be/talk_topic/dto/response/TalkTopicSearchResponse.java
@@ -1,0 +1,20 @@
+package org.example.tokpik_be.talk_topic.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record TalkTopicSearchResponse(
+    @JsonProperty(required = true)
+    @Schema(type = "string", description = "제목", example = "MBTI/T발 너 C야?")
+    String title,
+
+    @JsonProperty(required = true)
+    @Schema(type = "string", description = "부제목", example = "MBTI, 확실히 알려드릴게요")
+    String subtitle,
+
+    @JsonProperty(required = true)
+    @Schema(type = "string", description = "대화태그", example = "요즘이슈")
+    String topicTag
+) {
+
+}

--- a/src/main/java/org/example/tokpik_be/talk_topic/service/TalkTopicQueryService.java
+++ b/src/main/java/org/example/tokpik_be/talk_topic/service/TalkTopicQueryService.java
@@ -1,0 +1,44 @@
+package org.example.tokpik_be.talk_topic.service;
+
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.example.tokpik_be.tag.domain.PlaceTag;
+import org.example.tokpik_be.tag.domain.TopicTag;
+import org.example.tokpik_be.tag.entity.UserPlaceTag;
+import org.example.tokpik_be.tag.entity.UserTopicTag;
+import org.example.tokpik_be.talk_topic.dto.request.TalkTopicSearchRequest;
+import org.example.tokpik_be.talk_topic.dto.response.TalkTopicSearchResponse;
+import org.example.tokpik_be.user.domain.User;
+import org.example.tokpik_be.user.service.UserQueryService;
+import org.example.tokpik_be.util.llm.client.LLMApiClient;
+import org.example.tokpik_be.util.llm.dto.request.LLMTalkTopicSearchRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class TalkTopicQueryService {
+
+    private final UserQueryService userQueryService;
+    private final LLMApiClient llmApiClient;
+
+    public List<TalkTopicSearchResponse> searchTalkTopics(long userId,
+        TalkTopicSearchRequest request) {
+
+        User user = userQueryService.findById(userId);
+        LLMTalkTopicSearchRequest llmTalkTopicSearchRequest;
+
+        if (request.includeFilterCondition()) {
+            llmTalkTopicSearchRequest = LLMTalkTopicSearchRequest.from(request);
+        } else {
+            List<TopicTag> topicTags = user.getUserTopicTags().stream()
+                .map(UserTopicTag::getTopicTag).toList();
+            List<PlaceTag> placeTags = user.getUserPlaceTags().stream()
+                .map(UserPlaceTag::getPlaceTag).toList();
+            llmTalkTopicSearchRequest = LLMTalkTopicSearchRequest.from(topicTags, placeTags);
+        }
+
+        return llmApiClient.searchTalkTopics(llmTalkTopicSearchRequest);
+    }
+}

--- a/src/main/java/org/example/tokpik_be/user/domain/User.java
+++ b/src/main/java/org/example/tokpik_be/user/domain/User.java
@@ -3,16 +3,22 @@ package org.example.tokpik_be.user.domain;
 import jakarta.persistence.Column;
 import jakarta.persistence.Convert;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Objects;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.example.tokpik_be.common.BaseTimeEntity;
+import org.example.tokpik_be.tag.entity.UserPlaceTag;
+import org.example.tokpik_be.tag.entity.UserTopicTag;
 import org.example.tokpik_be.user.converter.GenderConverter;
 import org.example.tokpik_be.user.enums.Gender;
 
@@ -37,6 +43,12 @@ public class User extends BaseTimeEntity {
 
     @Convert(converter = GenderConverter.class)
     private Gender gender;
+
+    @OneToMany(fetch = FetchType.LAZY)
+    private List<UserTopicTag> userTopicTags = new ArrayList<>();
+
+    @OneToMany(fetch = FetchType.LAZY)
+    private List<UserPlaceTag> userPlaceTags = new ArrayList<>();
 
     public User(String email, String profilePhotoUrl) {
         this.email = email;

--- a/src/main/java/org/example/tokpik_be/util/llm/client/GPTApiClient.java
+++ b/src/main/java/org/example/tokpik_be/util/llm/client/GPTApiClient.java
@@ -1,0 +1,47 @@
+package org.example.tokpik_be.util.llm.client;
+
+import java.util.List;
+import org.example.tokpik_be.talk_topic.dto.response.TalkTopicSearchResponse;
+import org.example.tokpik_be.util.llm.dto.request.LLMTalkTopicSearchRequest;
+import org.example.tokpik_be.util.llm.dto.response.LLMTalkTopicsResponse;
+import org.springframework.ai.chat.model.ChatResponse;
+import org.springframework.ai.chat.prompt.Prompt;
+import org.springframework.ai.converter.BeanOutputConverter;
+import org.springframework.ai.openai.OpenAiChatModel;
+import org.springframework.ai.openai.OpenAiChatOptions;
+import org.springframework.ai.openai.api.OpenAiApi.ChatCompletionRequest.ResponseFormat;
+import org.springframework.ai.openai.api.OpenAiApi.ChatCompletionRequest.ResponseFormat.Type;
+import org.springframework.ai.openai.api.OpenAiApi.ChatModel;
+import org.springframework.stereotype.Component;
+
+@Component
+public class GPTApiClient implements LLMApiClient {
+
+    private final OpenAiChatModel chatModel;
+    private final BeanOutputConverter<LLMTalkTopicsResponse> outputConverter;
+    private final OpenAiChatOptions chatOptions;
+
+    public GPTApiClient(OpenAiChatModel chatModel) {
+        this.chatModel = chatModel;
+        this.outputConverter = new BeanOutputConverter<>(LLMTalkTopicsResponse.class);
+
+        String jsonSchema = this.outputConverter.getJsonSchema();
+        this.chatOptions = OpenAiChatOptions.builder()
+            .withModel(ChatModel.GPT_4_O_MINI)
+            .withResponseFormat(new ResponseFormat(Type.JSON_SCHEMA, jsonSchema))
+            .build();
+    }
+
+    @Override
+    public List<TalkTopicSearchResponse> searchTalkTopics(LLMTalkTopicSearchRequest request) {
+
+        String promptContent = request.toPromptContent();
+
+        Prompt prompt = new Prompt(promptContent, this.chatOptions);
+        ChatResponse response = chatModel.call(prompt);
+        LLMTalkTopicsResponse talkTopicsResponse = outputConverter
+            .convert(response.getResult().getOutput().getContent());
+
+        return talkTopicsResponse.responses();
+    }
+}

--- a/src/main/java/org/example/tokpik_be/util/llm/client/LLMApiClient.java
+++ b/src/main/java/org/example/tokpik_be/util/llm/client/LLMApiClient.java
@@ -1,0 +1,10 @@
+package org.example.tokpik_be.util.llm.client;
+
+import java.util.List;
+import org.example.tokpik_be.talk_topic.dto.response.TalkTopicSearchResponse;
+import org.example.tokpik_be.util.llm.dto.request.LLMTalkTopicSearchRequest;
+
+public interface LLMApiClient {
+
+    List<TalkTopicSearchResponse> searchTalkTopics(LLMTalkTopicSearchRequest request);
+}

--- a/src/main/java/org/example/tokpik_be/util/llm/dto/request/LLMTalkTopicSearchRequest.java
+++ b/src/main/java/org/example/tokpik_be/util/llm/dto/request/LLMTalkTopicSearchRequest.java
@@ -1,0 +1,85 @@
+package org.example.tokpik_be.util.llm.dto.request;
+
+import java.util.List;
+import lombok.Builder;
+import org.example.tokpik_be.tag.domain.PlaceTag;
+import org.example.tokpik_be.tag.domain.TopicTag;
+import org.example.tokpik_be.talk_topic.dto.request.TalkTopicSearchRequest;
+import org.springframework.util.CollectionUtils;
+
+@Builder
+public record LLMTalkTopicSearchRequest(
+    List<String> talkPurposes,
+    List<String> talkPlaces,
+    List<String> talkSituations,
+    List<String> talkMoods,
+    Boolean talkPartnerGender,
+    Integer talkPartnerAgeLowerBound,
+    Integer talkPartnerAgeUpperBound
+) {
+
+    public static LLMTalkTopicSearchRequest from(List<TopicTag> topicTags,
+        List<PlaceTag> placeTags) {
+
+        List<String> talkPurposes = topicTags.stream().map(TopicTag::getContent).toList();
+        List<String> talkPlaces = placeTags.stream().map(PlaceTag::getContent).toList();
+
+        return LLMTalkTopicSearchRequest.builder()
+            .talkPurposes(talkPurposes)
+            .talkPlaces(talkPlaces)
+            .build();
+    }
+
+    public static LLMTalkTopicSearchRequest from(TalkTopicSearchRequest request) {
+
+        return LLMTalkTopicSearchRequest.builder()
+            .talkPurposes(request.talkPurposes())
+            .talkSituations(request.talkSituations())
+            .talkMoods(request.talkMoods())
+            .talkPartnerGender(request.talkPartnerGender())
+            .talkPartnerAgeLowerBound(request.talkPartnerAgeLowerBound())
+            .talkPartnerAgeUpperBound(request.talkPartnerAgeUpperBound())
+            .build();
+    }
+
+    public String toPromptContent() {
+
+        String promptContent = """
+            당신은 상황에 맞는 대화 주제를 추천해주는 전문가입니다. 다음 정보를 바탕으로 10개의 대화 주제를 추천해주세요.
+            1. 대화 목적 : %s
+            2. 대화 장소 : %s
+            3. 대화 상황 : %s
+            4. 대화 분위기 : %s,
+            5. 대화 상대방 성별 : %s,
+            6. 대화 상대방 연령대 : %s ~ %s세
+                        
+            다음 사항을 준수하며 대화 주제를 추천해주세요:
+            - 각 주제는 주어진 상황, 맥락에 적절해야 합니다.
+            - 대화 목적, 장소, 상황, 분위기에 여러 옵션이 속하는 경우, 각 옵션 중 하나 이상 부합하는 주제를 선정하세요.
+                모든 옵션을 동시에 만족할 필요는 없습니다.
+            - 상대방의 성별과 나이에 적합한 주제를 고르세요.
+            - 대화 주제를 제시할 때 대화 주제 제목은 20자 내외, 대화 부제는 30자 내외로 제시해주세요.
+            - 문화적 차이, 민감한 주제는 조심스럽게 다루어주세요.
+            - 주어진 응답 형식을 엄수해주세요.
+            - null로 제시된 옵션을 무시해주세요.
+            - 전형적이지 않고 재치 넘치는 주제를 선정해주세요.
+            - 다음 예시를 참고해주세요.
+                title : MBTI / T발 너 C야?, subtitle: MBTI, 확실하게 알려드릴게요, topicTag : 요즘 이슈
+            """;
+
+        return promptContent.formatted(
+            generatePromptConditions(this.talkPurposes),
+            generatePromptConditions(this.talkPlaces),
+            generatePromptConditions(this.talkSituations),
+            generatePromptConditions(this.talkMoods),
+            this.talkPartnerGender,
+            this.talkPartnerAgeLowerBound,
+            this.talkPartnerAgeUpperBound
+        );
+    }
+
+    private String generatePromptConditions(List<String> conditions) {
+
+        return CollectionUtils.isEmpty(conditions) ? null : String.join(", ", conditions);
+    }
+}

--- a/src/main/java/org/example/tokpik_be/util/llm/dto/response/LLMTalkTopicsResponse.java
+++ b/src/main/java/org/example/tokpik_be/util/llm/dto/response/LLMTalkTopicsResponse.java
@@ -1,0 +1,12 @@
+package org.example.tokpik_be.util.llm.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
+import org.example.tokpik_be.talk_topic.dto.response.TalkTopicSearchResponse;
+
+public record LLMTalkTopicsResponse(
+    @JsonProperty(required = true)
+    List<TalkTopicSearchResponse> responses
+) {
+
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -13,3 +13,7 @@ spring:
   jpa:
     hibernate:
       ddl-auto: none
+
+  ai:
+    openai:
+      api-key: ${OPEN_AI_API_KEY}

--- a/src/test/java/org/example/tokpik_be/TokpikBeApplicationTests.java
+++ b/src/test/java/org/example/tokpik_be/TokpikBeApplicationTests.java
@@ -2,7 +2,9 @@ package org.example.tokpik_be;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
+@ActiveProfiles("dev")
 @SpringBootTest
 class TokpikBeApplicationTests {
 


### PR DESCRIPTION
## 작업 대상
<!-- 작업 대상을 설명 -->
- 대화 주제 조회(검색) 기능 개발

## 📄 작업 내용
<!-- 작업한 내용을 간단히 요약해주세요. -->
- 대화 주제를 GPT API를 통해 생성하는 로직 추가
- 사용자가 검색 필터 조건을 활용할 경우 해당 조건 바탕, GPT 요청 프롬프트 생성
- 검색 필터 조건을 설정하지 않을 경우, 사용자 부가 정보(대화 주제 태그, 대화 상황 태그) 바탕 요청 프롬프트 생성
- 다양한 LLM을 활용할 가능성 고려, 대화 주제 생성 메서드를 상위 인터페이스로 정의, 구현체로 GPT Client 구성
- GPT API 장애 처리 로직 추가, 프롬프트 개선 예정

## 📎 레퍼런스
<!-- 작업 시 참고했던 문건의 URL을 남겨주세요 -->