### PR TITLE
access token refresh시 refresh token도 갱신토록 수정

### DIFF
--- a/src/main/java/org/example/tokpik_be/login/dto/response/AccessTokenRefreshResponse.java
+++ b/src/main/java/org/example/tokpik_be/login/dto/response/AccessTokenRefreshResponse.java
@@ -4,7 +4,10 @@ import io.swagger.v3.oas.annotations.media.Schema;
 
 public record AccessTokenRefreshResponse(
     @Schema(type = "string", description = "새로운 access token", example = "header.payload.signature")
-    String accessToken
+    String accessToken,
+
+    @Schema(type = "string", description = "새로운 refresh token", example = "header.payload.signature")
+    String refreshToken
 ) {
 
 }

--- a/src/main/java/org/example/tokpik_be/login/service/LoginCommandService.java
+++ b/src/main/java/org/example/tokpik_be/login/service/LoginCommandService.java
@@ -58,7 +58,9 @@ public class LoginCommandService {
 
         Date generateAt = new Date();
         String accessToken = jwtUtil.generateAccessToken(userId, generateAt);
+        String newRefreshToken = jwtUtil.generateRefreshToken(userId, generateAt);
+        user.updateRefreshToken(newRefreshToken);
 
-        return new AccessTokenRefreshResponse(accessToken);
+        return new AccessTokenRefreshResponse(accessToken, newRefreshToken);
     }
 }

--- a/src/test/java/org/example/tokpik_be/login/controller/LoginControllerTest.java
+++ b/src/test/java/org/example/tokpik_be/login/controller/LoginControllerTest.java
@@ -44,7 +44,7 @@ class LoginControllerTest extends ControllerTestSupport {
             String jwt = "header.payload.signature";
             AccessTokenRefreshRequest request = new AccessTokenRefreshRequest(jwt);
 
-            AccessTokenRefreshResponse response = new AccessTokenRefreshResponse(jwt);
+            AccessTokenRefreshResponse response = new AccessTokenRefreshResponse(jwt, jwt);
             given(loginCommandService.refreshAccessToken(request)).willReturn(response);
 
             // when
@@ -54,7 +54,8 @@ class LoginControllerTest extends ControllerTestSupport {
 
             // then
             resultActions.andExpect(status().isOk())
-                .andExpect(jsonPath("$.accessToken").value(response.accessToken()));
+                .andExpect(jsonPath("$.accessToken").value(response.accessToken()))
+                .andExpect(jsonPath("$.refreshToken").value(response.refreshToken()));
         }
 
         @DisplayName("refresh token은 필수값이며, 빈 문자열이거나 공백일 수 없다.")

--- a/src/test/java/org/example/tokpik_be/login/service/LoginCommandServiceTest.java
+++ b/src/test/java/org/example/tokpik_be/login/service/LoginCommandServiceTest.java
@@ -1,6 +1,5 @@
 package org.example.tokpik_be.login.service;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -8,6 +7,7 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 
 import java.util.Date;
+import org.assertj.core.api.SoftAssertions;
 import org.example.tokpik_be.exception.GeneralException;
 import org.example.tokpik_be.exception.LoginException;
 import org.example.tokpik_be.exception.UserException;
@@ -55,12 +55,16 @@ class LoginCommandServiceTest {
             given(jwtUtil.parseUserIdFromToken(request.refreshToken())).willReturn(userId);
             given(userQueryService.findById(userId)).willReturn(user);
             given(jwtUtil.generateAccessToken(eq(userId), any(Date.class))).willReturn(jwt);
+            given(jwtUtil.generateRefreshToken(eq(userId), any(Date.class))).willReturn(jwt);
 
             // when
             AccessTokenRefreshResponse response = loginCommandService.refreshAccessToken(request);
 
             // then
-            assertThat(response.accessToken()).isEqualTo(jwt);
+            SoftAssertions.assertSoftly(softly -> {
+                softly.assertThat(response.accessToken()).isEqualTo(jwt);
+                softly.assertThat(response.refreshToken()).isEqualTo(jwt);
+            });
         }
 
         @DisplayName("access token이 유효하지 않을 경우 예외가 발생한다.")


### PR DESCRIPTION
## 작업 대상
<!-- 작업 대상을 설명 -->
- access token refresh 로직

## 📄 작업 내용
<!-- 작업한 내용을 간단히 요약해주세요. -->
- access token refresh시 refresh token도 갱신하여 새로 제공토록 로직 수정
- 잘못된  로직, RTR을 제대로 구현하도록 수정

## 📎 레퍼런스
<!-- 작업 시 참고했던 문건의 URL을 남겨주세요 -->