### PR TITLE
연관 대화 주제 조회 기능 개발

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -50,6 +50,12 @@ dependencies {
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.6'
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.6'
 
+    // querydsl
+    implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+    annotationProcessor "com.querydsl:querydsl-apt:5.0.0:jakarta"
+    annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+    annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+
     // mysql
     runtimeOnly 'com.mysql:mysql-connector-j'
 
@@ -69,4 +75,8 @@ dependencyManagement {
 
 tasks.named('test') {
     useJUnitPlatform()
+}
+
+clean {
+    delete file('src/main/generated')
 }

--- a/src/main/java/org/example/tokpik_be/config/QueryDslConfig.java
+++ b/src/main/java/org/example/tokpik_be/config/QueryDslConfig.java
@@ -1,0 +1,20 @@
+package org.example.tokpik_be.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@RequiredArgsConstructor
+public class QueryDslConfig {
+
+    private final EntityManager entityManager;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+
+        return new JPAQueryFactory(entityManager);
+    }
+}

--- a/src/main/java/org/example/tokpik_be/talk_topic/controller/TalkTopicController.java
+++ b/src/main/java/org/example/tokpik_be/talk_topic/controller/TalkTopicController.java
@@ -5,9 +5,13 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.example.tokpik_be.talk_topic.dto.request.TalkTopicSearchRequest;
+import org.example.tokpik_be.talk_topic.dto.response.TalkTopicsRelatedResponse;
 import org.example.tokpik_be.talk_topic.dto.response.TalkTopicsSearchResponse;
 import org.example.tokpik_be.talk_topic.service.TalkTopicCommandService;
+import org.example.tokpik_be.talk_topic.service.TalkTopicQueryService;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestAttribute;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -19,9 +23,10 @@ import org.springframework.web.bind.annotation.RestController;
 public class TalkTopicController {
 
     private final TalkTopicCommandService talkTopicCommandService;
+    private final TalkTopicQueryService talkTopicQueryService;
 
-    @Operation(summary = "대화 주제 조회(검색)", description = "대화 주제 조회(검색) API")
-    @ApiResponse(responseCode = "200" ,description = "대화 주제 검색 성공")
+    @Operation(summary = "대화 주제 조회(검색)", description = "대화 주제 조회(검색")
+    @ApiResponse(responseCode = "200", description = "대화 주제 검색 성공")
     @PostMapping("/topics")
     public ResponseEntity<TalkTopicsSearchResponse> searchTalkTopics(
         @RequestAttribute("userId") long userId,
@@ -29,6 +34,19 @@ public class TalkTopicController {
 
         TalkTopicsSearchResponse response = talkTopicCommandService
             .generateTopics(userId, request);
+
+        return ResponseEntity.ok().body(response);
+    }
+
+    @Operation(summary = "연관 대화 주제 조회", description = "연관 대화 주제 조회")
+    @ApiResponse(responseCode = "200", description = "연관 대화 주제 조회 성공")
+    @GetMapping("/topics/{topicId}/related")
+    public ResponseEntity<TalkTopicsRelatedResponse> getRelatedTalkTopics(
+        @RequestAttribute("userId") long userId,
+        @PathVariable("topicId") long topicId) {
+
+        TalkTopicsRelatedResponse response = talkTopicQueryService
+            .getRelatedTopics(userId, topicId);
 
         return ResponseEntity.ok().body(response);
     }

--- a/src/main/java/org/example/tokpik_be/talk_topic/domain/TalkTopic.java
+++ b/src/main/java/org/example/tokpik_be/talk_topic/domain/TalkTopic.java
@@ -7,7 +7,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
-import jakarta.persistence.OneToOne;
+import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -37,11 +37,11 @@ public class TalkTopic {
     @Embedded
     private TalkPartner partner;
 
-    @OneToOne
+    @ManyToOne
     @JoinColumn(name = "talk_topic_tag_id")
     private TopicTag topicTag;
 
-    @OneToOne
+    @ManyToOne
     @JoinColumn(name = "talk_place_tag_id")
     private PlaceTag placeTag;
 

--- a/src/main/java/org/example/tokpik_be/talk_topic/dto/response/TalkTopicsRelatedResponse.java
+++ b/src/main/java/org/example/tokpik_be/talk_topic/dto/response/TalkTopicsRelatedResponse.java
@@ -1,0 +1,26 @@
+package org.example.tokpik_be.talk_topic.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+
+public record TalkTopicsRelatedResponse(
+    @Schema(type = "array", description = "연관 대화 주제들")
+    List<TalkTopicRelatedResponse> talkTopics
+) {
+
+    public record TalkTopicRelatedResponse(
+        @Schema(type = "number", description = "대화 주제 ID", example = "1")
+        long topicId,
+
+        @Schema(type = "string", description = "대화 주제 종류", example = "인관관계")
+        String type,
+
+        @Schema(type = "string", description = "대화 주제 제목", example = "쓰@껄하게 스몰톡하는 법")
+        String title,
+
+        @Schema(type = "boolean", description = "스크랩 여부", example = "false")
+        boolean scraped
+    ) {
+
+    }
+}

--- a/src/main/java/org/example/tokpik_be/talk_topic/repository/QueryDslTalkTopicRepository.java
+++ b/src/main/java/org/example/tokpik_be/talk_topic/repository/QueryDslTalkTopicRepository.java
@@ -1,0 +1,53 @@
+package org.example.tokpik_be.talk_topic.repository;
+
+import static org.example.tokpik_be.scrap.domain.QScrap.scrap;
+import static org.example.tokpik_be.scrap.domain.QScrapTopic.scrapTopic;
+import static org.example.tokpik_be.tag.domain.QPlaceTag.placeTag;
+import static org.example.tokpik_be.tag.domain.QTopicTag.topicTag;
+import static org.example.tokpik_be.talk_topic.domain.QTalkTopic.talkTopic;
+
+import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.JPAExpressions;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.example.tokpik_be.talk_topic.domain.TalkTopic;
+import org.example.tokpik_be.talk_topic.dto.response.TalkTopicsRelatedResponse;
+import org.example.tokpik_be.talk_topic.dto.response.TalkTopicsRelatedResponse.TalkTopicRelatedResponse;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class QueryDslTalkTopicRepository {
+
+    private final JPAQueryFactory jpaQueryFactory;
+
+    public TalkTopicsRelatedResponse findRelatedTalkTopics(long userId, TalkTopic baseTopic) {
+        List<TalkTopicRelatedResponse> relatedTopics = jpaQueryFactory.from(talkTopic)
+            .select(Projections.constructor(TalkTopicRelatedResponse.class,
+                talkTopic.id,
+                talkTopic.topicTag.content,
+                talkTopic.title,
+                JPAExpressions.selectOne()
+                    .from(scrapTopic)
+                    .innerJoin(scrapTopic.scrap, scrap)
+                    .where(scrapTopic.talkTopic.id.eq(talkTopic.id).and(scrap.user.id.eq(userId)))
+                    .exists()
+                    .as("scraped")
+            ))
+            .innerJoin(talkTopic.topicTag, topicTag)
+            .innerJoin(talkTopic.placeTag, placeTag)
+            .where(
+                talkTopic.topicTag.id.eq(baseTopic.getTopicTag().getId()),
+                talkTopic.placeTag.id.eq(baseTopic.getPlaceTag().getId()),
+                talkTopic.situation.contains(baseTopic.getSituation()),
+                talkTopic.partner.gender.eq(baseTopic.getPartner().getGender()),
+                talkTopic.partner.ageLowerBound.goe(baseTopic.getPartner().getAgeLowerBound()),
+                talkTopic.partner.ageUpperBound.loe(baseTopic.getPartner().getAgeUpperBound()),
+                talkTopic.id.ne(baseTopic.getId()))
+            .limit(10)
+            .fetch();
+
+        return new TalkTopicsRelatedResponse(relatedTopics);
+    }
+}

--- a/src/main/java/org/example/tokpik_be/talk_topic/service/TalkTopicQueryService.java
+++ b/src/main/java/org/example/tokpik_be/talk_topic/service/TalkTopicQueryService.java
@@ -4,7 +4,11 @@ import lombok.RequiredArgsConstructor;
 import org.example.tokpik_be.exception.GeneralException;
 import org.example.tokpik_be.exception.TalkTopicException;
 import org.example.tokpik_be.talk_topic.domain.TalkTopic;
+import org.example.tokpik_be.talk_topic.dto.response.TalkTopicsRelatedResponse;
+import org.example.tokpik_be.talk_topic.repository.QueryDslTalkTopicRepository;
 import org.example.tokpik_be.talk_topic.repository.TalkTopicRepository;
+import org.example.tokpik_be.user.domain.User;
+import org.example.tokpik_be.user.service.UserQueryService;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -14,10 +18,20 @@ import org.springframework.transaction.annotation.Transactional;
 public class TalkTopicQueryService {
 
     private final TalkTopicRepository talkTopicRepository;
+    private final QueryDslTalkTopicRepository queryDslTalkTopicRepository;
+
+    private final UserQueryService userQueryService;
 
     public TalkTopic findById(long topicId) {
 
         return talkTopicRepository.findById(topicId)
             .orElseThrow(() -> new GeneralException(TalkTopicException.TALK_TOPIC_NOT_FOUND));
+    }
+
+    public TalkTopicsRelatedResponse getRelatedTopics(long userId, long topicId) {
+        User user = userQueryService.findById(userId);
+        TalkTopic baseTopic = findById(topicId);
+
+        return queryDslTalkTopicRepository.findRelatedTalkTopics(user.getId(), baseTopic);
     }
 }

--- a/src/test/java/org/example/tokpik_be/talk_topic/repository/QueryDslTalkTopicRepositoryTest.java
+++ b/src/test/java/org/example/tokpik_be/talk_topic/repository/QueryDslTalkTopicRepositoryTest.java
@@ -1,0 +1,308 @@
+package org.example.tokpik_be.talk_topic.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import java.util.List;
+import java.util.stream.IntStream;
+import org.assertj.core.api.SoftAssertions;
+import org.example.tokpik_be.config.QueryDslConfig;
+import org.example.tokpik_be.scrap.domain.Scrap;
+import org.example.tokpik_be.scrap.domain.ScrapTopic;
+import org.example.tokpik_be.tag.domain.PlaceTag;
+import org.example.tokpik_be.tag.domain.TopicTag;
+import org.example.tokpik_be.talk_topic.domain.TalkPartner;
+import org.example.tokpik_be.talk_topic.domain.TalkTopic;
+import org.example.tokpik_be.talk_topic.dto.response.TalkTopicsRelatedResponse;
+import org.example.tokpik_be.talk_topic.dto.response.TalkTopicsRelatedResponse.TalkTopicRelatedResponse;
+import org.example.tokpik_be.user.domain.User;
+import org.example.tokpik_be.user.enums.Gender;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+
+@ActiveProfiles("test")
+@Import(QueryDslConfig.class)
+@DataJpaTest
+class QueryDslTalkTopicRepositoryTest {
+
+    @Autowired
+    private EntityManager em;
+
+    @Autowired
+    private JPAQueryFactory jpaQueryFactory;
+
+    private QueryDslTalkTopicRepository queryDslTalkTopicRepository;
+
+    private User user;
+    private TopicTag topicTag;
+    private PlaceTag placeTag;
+    private TalkTopic baseTopic;
+    private TalkPartner talkPartner;
+
+    @BeforeEach
+    void setUp() {
+        queryDslTalkTopicRepository = new QueryDslTalkTopicRepository(jpaQueryFactory);
+
+        // 사용자 저장
+        user = new User("mj3242@naver.com", "profile_photo_url");
+        em.persist(user);
+        em.flush();
+
+        // 대화 종류 태그 저장
+        topicTag = new TopicTag("example-topicTag");
+        em.persist(topicTag);
+        em.flush();
+
+        // 대화 장소 태그 저장
+        placeTag = new PlaceTag("example-placeTag");
+        em.persist(placeTag);
+        em.flush();
+
+        // 6개의 대화 주제들 저장
+        talkPartner = new TalkPartner(Gender.MALE, 20, 29);
+        List<TalkTopic> talkTopics = IntStream.range(0, 7)
+            .mapToObj(i -> new TalkTopic("title",
+                "subtitle",
+                "situation",
+                talkPartner,
+                topicTag,
+                placeTag))
+            .toList();
+        baseTopic = talkTopics.get(0);
+
+        talkTopics.forEach(em::persist);
+        em.flush();
+
+        // 스크랩 생성
+        Scrap scrap = new Scrap("example-scrap", user);
+        em.persist(scrap);
+        em.flush();
+
+        // 4개의 스크랩 대화 주제 저장
+        List<TalkTopic> scrapTalkTopics = talkTopics.subList(0, 4);
+        scrapTalkTopics.stream()
+            .map(talkTopic -> new ScrapTopic(scrap, talkTopic))
+            .forEach(em::persist);
+        em.flush();
+    }
+
+    @AfterEach
+    void tearDown() {
+        em.clear();
+        em.createQuery("DELETE FROM ScrapTopic").executeUpdate();
+        em.createQuery("DELETE FROM Scrap").executeUpdate();
+        em.createQuery("DELETE FROM TalkTopic").executeUpdate();
+        em.createQuery("DELETE FROM User").executeUpdate();
+        em.createQuery("DELETE FROM TopicTag").executeUpdate();
+        em.createQuery("DELETE FROM PlaceTag").executeUpdate();
+        em.flush();
+    }
+
+    @DisplayName("연관 주제를 조회할 수 있다.")
+    @Test
+    void findRelatedTalkTopics() {
+        // given
+
+        // when
+        TalkTopicsRelatedResponse result = queryDslTalkTopicRepository
+            .findRelatedTalkTopics(user.getId(), baseTopic);
+
+        // then
+        List<TalkTopicRelatedResponse> relatedTalkTopics = result.talkTopics();
+        SoftAssertions.assertSoftly(softly -> {
+            // 연관된 주제 모두 조회하였는 지 검증
+            softly.assertThat(relatedTalkTopics).hasSize(6);
+
+            // 조회된 주제들의 대화 종류가 모두 일치하는 지 검증
+            List<String> topicTagContents = relatedTalkTopics.stream()
+                .map(TalkTopicRelatedResponse::type)
+                .toList();
+            softly.assertThat(topicTagContents).allMatch(
+                topicTagContent -> baseTopic.getTopicTag().getContent().equals(topicTagContent));
+
+            // 조회된 주제들중 스크랩된 주제들의 스크랩 여부 검증
+            List<TalkTopicRelatedResponse> scrapedTalkTopics = relatedTalkTopics.stream()
+                .filter(TalkTopicRelatedResponse::scraped)
+                .toList();
+            softly.assertThat(scrapedTalkTopics).hasSize(3);
+        });
+    }
+
+    @DisplayName("연관 대화 주제 조회시 다른 대화 장소인 주제는 조회하지 않는다.")
+    @Test
+    void differentPlaceTag() {
+        // given
+        PlaceTag otherPlaceTag = new PlaceTag("집");
+        em.persist(otherPlaceTag);
+        em.flush();
+
+        List<TalkTopic> unrelatedTalkTopics = IntStream.range(0, 2)
+            .mapToObj(i -> new TalkTopic("title",
+                "subtitle",
+                "situation",
+                talkPartner,
+                topicTag,
+                otherPlaceTag))
+            .toList();
+        unrelatedTalkTopics.forEach(em::persist);
+        em.flush();
+
+        // when
+        TalkTopicsRelatedResponse result = queryDslTalkTopicRepository
+            .findRelatedTalkTopics(user.getId(), baseTopic);
+
+        // then
+        List<Long> unrelatedTalkTopicIds = extractTalkTopicIds(unrelatedTalkTopics);
+        List<Long> relatedTalkTopicIds = extractTopicIdsFromResult(result);
+        assertThat(relatedTalkTopicIds).doesNotContainAnyElementsOf(unrelatedTalkTopicIds);
+    }
+
+    @DisplayName("연관 대화 주제 조회시 다른 대화 종류인 주제는 조회하지 않는다.")
+    @Test
+    void differentTopicTag() {
+        // given
+        TopicTag otherTopicTag = new TopicTag("비즈니스");
+        em.persist(otherTopicTag);
+        em.flush();
+
+        List<TalkTopic> unrelatedTalkTopics = IntStream.range(0, 2)
+            .mapToObj(i -> new TalkTopic("title",
+                "subtitle",
+                "situation",
+                talkPartner,
+                otherTopicTag,
+                placeTag))
+            .toList();
+        unrelatedTalkTopics.forEach(em::persist);
+        em.flush();
+
+        // when
+        TalkTopicsRelatedResponse result = queryDslTalkTopicRepository
+            .findRelatedTalkTopics(user.getId(), baseTopic);
+
+        // then
+        List<Long> unrelatedTalkTopicIds = extractTalkTopicIds(unrelatedTalkTopics);
+        List<Long> relatedTalkTopicIds = extractTopicIdsFromResult(result);
+        assertThat(relatedTalkTopicIds).doesNotContainAnyElementsOf(unrelatedTalkTopicIds);
+    }
+
+    @DisplayName("연관 대화 주제 조회시 기준 주제 대화 상황을 포함하지 않는 주제는 조회하지 않는다.")
+    @Test
+    void doesNotIncludeBaseTopicSituation() {
+        // given
+        String otherSituation = "otherSituation";
+        List<TalkTopic> unrelatedTalkTopics = IntStream.range(0, 2)
+            .mapToObj(i -> new TalkTopic("title",
+                "subtitle",
+                otherSituation,
+                talkPartner,
+                topicTag,
+                placeTag))
+            .toList();
+        unrelatedTalkTopics.forEach(em::persist);
+        em.flush();
+
+        // when
+        TalkTopicsRelatedResponse result = queryDslTalkTopicRepository
+            .findRelatedTalkTopics(user.getId(), baseTopic);
+
+        // then
+        List<Long> unrelatedTalkTopicIds = extractTalkTopicIds(unrelatedTalkTopics);
+        List<Long> relatedTalkTopicIds = extractTopicIdsFromResult(result);
+        assertThat(relatedTalkTopicIds).doesNotContainAnyElementsOf(unrelatedTalkTopicIds);
+    }
+
+    @DisplayName("연관 대화 주제 조회시 기준 주제의 대화 상대 성별과 일치하는 주제만을 조회한다.")
+    @Test
+    void differentPartnerGender() {
+        // given
+        Gender differentGender = Gender.FEMALE;
+        TalkPartner differentPartner = new TalkPartner(differentGender,
+            talkPartner.getAgeLowerBound(),
+            talkPartner.getAgeUpperBound());
+
+        List<TalkTopic> unrelatedTalkTopics = IntStream.range(0, 2)
+            .mapToObj(i -> new TalkTopic("title",
+                "subtitle",
+                "situation",
+                differentPartner,
+                topicTag,
+                placeTag))
+            .toList();
+        unrelatedTalkTopics.forEach(em::persist);
+        em.flush();
+
+        // when
+        TalkTopicsRelatedResponse result = queryDslTalkTopicRepository
+            .findRelatedTalkTopics(user.getId(), baseTopic);
+
+        // then
+        List<Long> unrelatedTalkTopicIds = extractTalkTopicIds(unrelatedTalkTopics);
+        List<Long> relatedTalkTopicIds = extractTopicIdsFromResult(result);
+        assertThat(relatedTalkTopicIds).doesNotContainAnyElementsOf(unrelatedTalkTopicIds);
+    }
+
+    @DisplayName("연관 대화 주제 조회시 기준 주제 대화 상대 연령대에 포함되는 주제만을 조회한다.")
+    @Test
+    void outOfPartnerAgeRange() {
+        // given
+        List<TalkPartner> talkPartners = List.of(
+            new TalkPartner(talkPartner.getGender(),
+                talkPartner.getAgeLowerBound() - 1,
+                talkPartner.getAgeUpperBound()),
+            new TalkPartner(talkPartner.getGender(),
+                talkPartner.getAgeLowerBound(),
+                talkPartner.getAgeUpperBound() + 1
+            ));
+        List<TalkTopic> unrelatedTalkTopics = talkPartners.stream().map(partner -> new TalkTopic(
+                "title",
+                "subtitle",
+                "situation",
+                partner,
+                topicTag,
+                placeTag))
+            .toList();
+        unrelatedTalkTopics.forEach(em::persist);
+        em.flush();
+
+        // when
+        TalkTopicsRelatedResponse result = queryDslTalkTopicRepository
+            .findRelatedTalkTopics(user.getId(), baseTopic);
+
+        // then
+        List<Long> unrelatedTalkTopicIds = extractTalkTopicIds(unrelatedTalkTopics);
+        List<Long> relatedTalkTopicIds = extractTopicIdsFromResult(result);
+        assertThat(relatedTalkTopicIds).doesNotContainAnyElementsOf(unrelatedTalkTopicIds);
+    }
+
+    @DisplayName("연관 주제 조회시 기준 주제는 포함되지 않는다.")
+    @Test
+    void notIncludeBaseTopic() {
+        // given
+
+        // when
+        TalkTopicsRelatedResponse result = queryDslTalkTopicRepository
+            .findRelatedTalkTopics(user.getId(), baseTopic);
+
+        // then
+        List<Long> relatedTalkTopicIds = extractTopicIdsFromResult(result);
+        assertThat(relatedTalkTopicIds).doesNotContain(baseTopic.getId());
+    }
+
+    private List<Long> extractTalkTopicIds(List<TalkTopic> talkTopics) {
+
+        return talkTopics.stream().map(TalkTopic::getId).toList();
+    }
+
+    private List<Long> extractTopicIdsFromResult(TalkTopicsRelatedResponse result) {
+
+        return result.talkTopics().stream().map(TalkTopicRelatedResponse::topicId).toList();
+    }
+}

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -1,0 +1,17 @@
+spring:
+  config:
+    activate:
+      on-profile: test
+
+  datasource:
+    url: jdbc:h2:mem:testdb
+    username: sa
+    password:
+
+  jpa:
+    hibernate:
+      ddl-auto: create-drop
+    properties:
+      hibernate:
+        format_sql: true
+        show_sql: true


### PR DESCRIPTION
## 작업 대상
<!-- 작업 대상을 설명 -->
- 연관 대화 주제 조회 기능

## 📄 작업 내용
<!-- 작업한 내용을 간단히 요약해주세요. -->
- 연관 대화 주제 조회 비즈니스 로직 & API 개발
- 기준이 되는 대화 주제의 조건들에 부합하는 주제들만 조회
- 조건은 다음과 같다.
    - 동일한 대화 종류(`topicTag`)
    - 동일한 대화 장소
    - 기준 주제의 대화 상황 내용을 대화 상황 내에 포함
    - 기준 주제와 동일한 대화 상대 성별
    - 기준 주제의 대화 상대 연령대와 연령대 일치 혹은 포함
- 정렬 조건과 페이지네이션 도입 여부 결정에 따라 추후 수정 예정

## 📎 레퍼런스
<!-- 작업 시 참고했던 문건의 URL을 남겨주세요 -->