### PR TITLE
대화 주제 상세 조회 기능 개발

### DIFF
--- a/src/main/java/org/example/tokpik_be/scrap/repository/QueryDslScrapRepository.java
+++ b/src/main/java/org/example/tokpik_be/scrap/repository/QueryDslScrapRepository.java
@@ -1,0 +1,28 @@
+package org.example.tokpik_be.scrap.repository;
+
+import static org.example.tokpik_be.scrap.domain.QScrapTopic.scrapTopic;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.Objects;
+import lombok.RequiredArgsConstructor;
+import org.example.tokpik_be.talk_topic.domain.TalkTopic;
+import org.example.tokpik_be.user.domain.User;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class QueryDslScrapRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    public boolean checkTopicScrapedBy(User user, TalkTopic talkTopic) {
+
+        Integer result = queryFactory.selectOne()
+            .from(scrapTopic)
+            .where(scrapTopic.scrap.user.id.eq(user.getId())
+                .and(scrapTopic.talkTopic.id.eq(talkTopic.getId())))
+            .fetchOne();
+
+        return Objects.nonNull(result);
+    }
+}

--- a/src/main/java/org/example/tokpik_be/talk_topic/controller/TalkTopicController.java
+++ b/src/main/java/org/example/tokpik_be/talk_topic/controller/TalkTopicController.java
@@ -1,10 +1,13 @@
 package org.example.tokpik_be.talk_topic.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.example.tokpik_be.talk_topic.dto.request.TalkTopicSearchRequest;
+import org.example.tokpik_be.talk_topic.dto.response.TalkTopicDetailResponse;
 import org.example.tokpik_be.talk_topic.dto.response.TalkTopicsRelatedResponse;
 import org.example.tokpik_be.talk_topic.dto.response.TalkTopicsSearchResponse;
 import org.example.tokpik_be.talk_topic.service.TalkTopicCommandService;
@@ -50,4 +53,19 @@ public class TalkTopicController {
 
         return ResponseEntity.ok().body(response);
     }
+
+    @Operation(summary = "대화 주제 상세 조회", description = "대화 주제 상세 내용 조회")
+    @ApiResponse(responseCode = "200", description = "대화 주제 상세 내용 조회 성공")
+    @GetMapping("/topics/{topicId}/details")
+    public ResponseEntity<TalkTopicDetailResponse> getTalkTopicDetail(
+        @RequestAttribute("userId") long userId,
+        @Parameter(name = "topicId", description = "대화 주제 ID", example = "1", in = ParameterIn.PATH)
+        @PathVariable("topicId") long topicId) {
+
+        TalkTopicDetailResponse response = talkTopicQueryService
+            .getTalkTopicDetail(userId, topicId);
+
+        return ResponseEntity.ok().body(response);
+    }
+
 }

--- a/src/main/java/org/example/tokpik_be/talk_topic/dto/response/TalkTopicDetailResponse.java
+++ b/src/main/java/org/example/tokpik_be/talk_topic/dto/response/TalkTopicDetailResponse.java
@@ -1,0 +1,23 @@
+package org.example.tokpik_be.talk_topic.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+
+public record TalkTopicDetailResponse(
+    @Schema(type = "array", description = "상세 내용 항목들")
+    List<TalkTopicDetailItemResponse> details,
+
+    @Schema(type = "boolean", description = "스크랩 여부", example = "false")
+    boolean scraped
+) {
+
+    public record TalkTopicDetailItemResponse(
+        @Schema(type = "string", description = "항목 제목", example = "개인적인 고민을 유도하며 공감")
+        String itemTitle,
+
+        @Schema(type = "string", description = "항목 내용", example = "상대방이 고민을 얘기하면...")
+        String itemContent
+    ) {
+
+    }
+}

--- a/src/main/java/org/example/tokpik_be/talk_topic/service/TalkTopicQueryService.java
+++ b/src/main/java/org/example/tokpik_be/talk_topic/service/TalkTopicQueryService.java
@@ -1,14 +1,21 @@
 package org.example.tokpik_be.talk_topic.service;
 
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.example.tokpik_be.exception.GeneralException;
 import org.example.tokpik_be.exception.TalkTopicException;
+import org.example.tokpik_be.scrap.repository.QueryDslScrapRepository;
 import org.example.tokpik_be.talk_topic.domain.TalkTopic;
+import org.example.tokpik_be.talk_topic.dto.response.TalkTopicDetailResponse;
+import org.example.tokpik_be.talk_topic.dto.response.TalkTopicDetailResponse.TalkTopicDetailItemResponse;
 import org.example.tokpik_be.talk_topic.dto.response.TalkTopicsRelatedResponse;
 import org.example.tokpik_be.talk_topic.repository.QueryDslTalkTopicRepository;
 import org.example.tokpik_be.talk_topic.repository.TalkTopicRepository;
 import org.example.tokpik_be.user.domain.User;
 import org.example.tokpik_be.user.service.UserQueryService;
+import org.example.tokpik_be.util.llm.client.LLMApiClient;
+import org.example.tokpik_be.util.llm.dto.request.LLMTalkTopicDetailRequest;
+import org.example.tokpik_be.util.llm.dto.response.LLMTalkTopicDetailResponse;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -19,8 +26,10 @@ public class TalkTopicQueryService {
 
     private final TalkTopicRepository talkTopicRepository;
     private final QueryDslTalkTopicRepository queryDslTalkTopicRepository;
+    private final QueryDslScrapRepository queryDslScrapRepository;
 
     private final UserQueryService userQueryService;
+    private final LLMApiClient llmApiClient;
 
     public TalkTopic findById(long topicId) {
 
@@ -33,5 +42,21 @@ public class TalkTopicQueryService {
         TalkTopic baseTopic = findById(topicId);
 
         return queryDslTalkTopicRepository.findRelatedTalkTopics(user.getId(), baseTopic);
+    }
+
+    public TalkTopicDetailResponse getTalkTopicDetail(long userId, long topicId) {
+        User user = userQueryService.findById(userId);
+        TalkTopic talkTopic = findById(topicId);
+
+        LLMTalkTopicDetailRequest request = LLMTalkTopicDetailRequest.from(talkTopic);
+        LLMTalkTopicDetailResponse llmResponse = llmApiClient
+            .generateTalkTopicDetail(request);
+
+        List<TalkTopicDetailItemResponse> details = llmResponse.details().stream()
+            .map(item -> new TalkTopicDetailItemResponse(item.itemTitle(), item.itemContent()))
+            .toList();
+        boolean scraped = queryDslScrapRepository.checkTopicScrapedBy(user, talkTopic);
+
+        return new TalkTopicDetailResponse(details, scraped);
     }
 }

--- a/src/main/java/org/example/tokpik_be/util/llm/client/GPTApiClient.java
+++ b/src/main/java/org/example/tokpik_be/util/llm/client/GPTApiClient.java
@@ -1,6 +1,9 @@
 package org.example.tokpik_be.util.llm.client;
 
+import lombok.RequiredArgsConstructor;
+import org.example.tokpik_be.util.llm.dto.request.LLMTalkTopicDetailRequest;
 import org.example.tokpik_be.util.llm.dto.request.LLMTalkTopicSearchRequest;
+import org.example.tokpik_be.util.llm.dto.response.LLMTalkTopicDetailResponse;
 import org.example.tokpik_be.util.llm.dto.response.LLMTalkTopicsResponse;
 import org.springframework.ai.chat.model.ChatResponse;
 import org.springframework.ai.chat.prompt.Prompt;
@@ -13,31 +16,46 @@ import org.springframework.ai.openai.api.OpenAiApi.ChatModel;
 import org.springframework.stereotype.Component;
 
 @Component
+@RequiredArgsConstructor
 public class GPTApiClient implements LLMApiClient {
 
     private final OpenAiChatModel chatModel;
-    private final BeanOutputConverter<LLMTalkTopicsResponse> outputConverter;
-    private final OpenAiChatOptions chatOptions;
-
-    public GPTApiClient(OpenAiChatModel chatModel) {
-        this.chatModel = chatModel;
-        this.outputConverter = new BeanOutputConverter<>(LLMTalkTopicsResponse.class);
-
-        String jsonSchema = this.outputConverter.getJsonSchema();
-        this.chatOptions = OpenAiChatOptions.builder()
-            .withModel(ChatModel.GPT_4_O_MINI)
-            .withResponseFormat(new ResponseFormat(Type.JSON_SCHEMA, jsonSchema))
-            .build();
-    }
 
     @Override
     public LLMTalkTopicsResponse searchTalkTopics(LLMTalkTopicSearchRequest request) {
 
-        String promptContent = request.toPromptContent();
+        BeanOutputConverter<LLMTalkTopicsResponse> outputConverter =
+            new BeanOutputConverter<>(LLMTalkTopicsResponse.class);
 
-        Prompt prompt = new Prompt(promptContent, this.chatOptions);
+        OpenAiChatOptions chatOptions = generateChatOptions(outputConverter.getJsonSchema());
+
+        String promptContent = request.toPromptContent();
+        Prompt prompt = new Prompt(promptContent, chatOptions);
         ChatResponse response = chatModel.call(prompt);
 
         return outputConverter.convert(response.getResult().getOutput().getContent());
+    }
+
+    @Override
+    public LLMTalkTopicDetailResponse generateTalkTopicDetail(LLMTalkTopicDetailRequest request) {
+
+        BeanOutputConverter<LLMTalkTopicDetailResponse> outputConverter =
+            new BeanOutputConverter<>(LLMTalkTopicDetailResponse.class);
+
+        OpenAiChatOptions chatOptions = generateChatOptions(outputConverter.getJsonSchema());
+
+        String promptContent = request.toPromptContent();
+        Prompt prompt = new Prompt(promptContent, chatOptions);
+        ChatResponse response = chatModel.call(prompt);
+
+        return outputConverter.convert(response.getResult().getOutput().getContent());
+    }
+
+    private OpenAiChatOptions generateChatOptions(String jsonSchema) {
+
+        return OpenAiChatOptions.builder()
+            .withModel(ChatModel.GPT_4_O_MINI)
+            .withResponseFormat(new ResponseFormat(Type.JSON_SCHEMA, jsonSchema))
+            .build();
     }
 }

--- a/src/main/java/org/example/tokpik_be/util/llm/client/LLMApiClient.java
+++ b/src/main/java/org/example/tokpik_be/util/llm/client/LLMApiClient.java
@@ -1,9 +1,13 @@
 package org.example.tokpik_be.util.llm.client;
 
+import org.example.tokpik_be.util.llm.dto.request.LLMTalkTopicDetailRequest;
 import org.example.tokpik_be.util.llm.dto.request.LLMTalkTopicSearchRequest;
+import org.example.tokpik_be.util.llm.dto.response.LLMTalkTopicDetailResponse;
 import org.example.tokpik_be.util.llm.dto.response.LLMTalkTopicsResponse;
 
 public interface LLMApiClient {
 
     LLMTalkTopicsResponse searchTalkTopics(LLMTalkTopicSearchRequest request);
+
+    LLMTalkTopicDetailResponse generateTalkTopicDetail(LLMTalkTopicDetailRequest request);
 }

--- a/src/main/java/org/example/tokpik_be/util/llm/dto/request/LLMTalkTopicDetailRequest.java
+++ b/src/main/java/org/example/tokpik_be/util/llm/dto/request/LLMTalkTopicDetailRequest.java
@@ -1,0 +1,56 @@
+package org.example.tokpik_be.util.llm.dto.request;
+
+import org.example.tokpik_be.talk_topic.domain.TalkPartner;
+import org.example.tokpik_be.talk_topic.domain.TalkTopic;
+
+public record LLMTalkTopicDetailRequest(
+    String title,
+    String subTitle,
+    String situation,
+    TalkPartner talkPartner,
+    String topicTag,
+    String placeTag
+) {
+
+    public static LLMTalkTopicDetailRequest from(TalkTopic talkTopic) {
+
+        return new LLMTalkTopicDetailRequest(talkTopic.getTitle(),
+            talkTopic.getSubtitle(),
+            talkTopic.getSituation(),
+            talkTopic.getPartner(),
+            talkTopic.getTopicTag().getContent(),
+            talkTopic.getPlaceTag().getContent());
+    }
+
+    public String toPromptContent() {
+        String promptContent = """
+            당신은 주어진 키워드들에 맞는 상세 대화 내용을 제시하는 전문가입니다.
+            다음 정보를 바탕으로 상세 내용을 항목 제목, 항목 내용 구성에 따라 제안해주세요.
+            응답의 itemTitle는 상세 내용 항목 제목으로 소제목 형태를 띄게 됩니다.
+            응답의 itemContent는 상세 내용 항목 내용으로  소제목별 세부 내용을 의미합니다.
+                        
+            1. 대화 주제 제목 : %s
+            2. 대화 주제 부제목 : %s
+            3. 대화 주제 분위기 : %s
+            4. 대화 상대 성별 : %s
+            5. 대화 상대 연령대 : %s ~ %s세
+            6. 대화 주제 분류 : %s
+            7. 대화 장소 : %s
+                        
+            다음 사항을 준수하여 상세 내용을 생성해주세요.
+            - 상세 내용은 주어진 키워드들에 적절해야 합니다.
+            - 상세 내용 항목은 5개 이내로 구성해주세요.
+            - 항목별 소제목은 30자 내외, 세부 내용은 100자 이상으로 구성해주세요.
+            - 전형적이지 않고 재치 넘치게 내용을 생성해주세요.
+            """;
+
+        return promptContent.formatted(
+            title,
+            subTitle,
+            situation,
+            talkPartner.getGender().getDescription(),
+            talkPartner.getAgeLowerBound(), talkPartner.getAgeUpperBound(),
+            topicTag,
+            placeTag);
+    }
+}

--- a/src/main/java/org/example/tokpik_be/util/llm/dto/response/LLMTalkTopicDetailResponse.java
+++ b/src/main/java/org/example/tokpik_be/util/llm/dto/response/LLMTalkTopicDetailResponse.java
@@ -1,0 +1,20 @@
+package org.example.tokpik_be.util.llm.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
+
+public record LLMTalkTopicDetailResponse(
+    @JsonProperty(required = true)
+    List<LLMTalkTopicDetailItemResponse> details
+) {
+
+    public record LLMTalkTopicDetailItemResponse(
+        @JsonProperty(required = true)
+        String itemTitle,
+
+        @JsonProperty(required = true)
+        String itemContent
+    ) {
+
+    }
+}


### PR DESCRIPTION
## 작업 대상
<!-- 작업 대상을 설명 -->
- 대화 주제 상세 조회 기능

## 📄 작업 내용
<!-- 작업한 내용을 간단히 요약해주세요. -->
- 대화 주제 상세 조회 비즈니스 로직 및 API 개발
- 상세 내용을 항목별로 나누어 제목/내용의 형식으로 GPT에게 응답 받도록 로직 구성
- 항목별 제목 30자 내외, 내용 100자 이상으로 제약 구성. 추후 조정 가능

## 📎 레퍼런스
<!-- 작업 시 참고했던 문건의 URL을 남겨주세요 -->