### PR TITLE
알림 목록 조회시 네 개의 알림 대화 주제 종류 제공토록 수정

### DIFF
--- a/src/main/java/org/example/tokpik_be/notification/dto/response/NotificationsResponse.java
+++ b/src/main/java/org/example/tokpik_be/notification/dto/response/NotificationsResponse.java
@@ -41,7 +41,7 @@ public record NotificationsResponse(
         @Schema(type = "number", description = "스크랩에 저장된 대화 주제 합계", example = "30")
         long notificationTopicTotal,
 
-        @Schema(type = "array", description = "알림 지정 순서에 따른 첫 세 대화 주제 종류들")
+        @Schema(type = "array", description = "알림 지정 순서에 따른 첫 네 대화 주제 종류들")
         List<NotificationTalkTopicTypeResponse> notificationTalkTopicTypes
     ) {
 

--- a/src/main/java/org/example/tokpik_be/notification/repository/QueryDslNotificationRepository.java
+++ b/src/main/java/org/example/tokpik_be/notification/repository/QueryDslNotificationRepository.java
@@ -84,7 +84,7 @@ public class QueryDslNotificationRepository {
         Map<Long, List<Tuple>> groupByNotificationId = results.stream()
             .collect(Collectors.groupingBy(result -> result.get(notification.id)));
 
-        // group 바탕으로 알림별 알림 대화 주제 ID(알림 지정 순서)에 따라 정렬, 첫 세 알림 대화 주제 선정, 응답 DTO로 매핑
+        // group 바탕으로 알림별 알림 대화 주제 ID(알림 지정 순서)에 따라 정렬, 첫 네 알림 대화 주제 선정, 응답 DTO로 매핑
         List<NotificationResponse> contents = groupByNotificationId.entrySet().stream()
             .map(entry -> {
                 long notificationId = entry.getKey();
@@ -92,10 +92,11 @@ public class QueryDslNotificationRepository {
 
                 long notificationTopicTotal = tuples.size();
 
+                int toIndex = Math.min(tuples.size(), 4);
                 List<NotificationTalkTopicTypeResponse> talkTopicTypeResponses = tuples
                     .stream()
                     .sorted(Comparator.comparing(r -> r.get(notificationTalkTopic.id)))
-                    .toList().subList(0, 3)
+                    .toList().subList(0, toIndex)
                     .stream()
                     .map(r -> new NotificationTalkTopicTypeResponse(r.get(topicTag.id),
                         r.get(topicTag.content)))


### PR DESCRIPTION
## 작업 대상
<!-- 작업 대상을 설명 -->
- 알림 목록 조회 로직

## 📄 작업 내용
<!-- 작업한 내용을 간단히 요약해주세요. -->
- 사용자에게 알림 제공시, 알림 지정 순서에 따른 첫 네 개의 알림 대화 주제 종류 제공
- 기존 세 개에서 네 개를 제공하도록 로직 수정

## 📎 레퍼런스
<!-- 작업 시 참고했던 문건의 URL을 남겨주세요 -->