### PR TITLE
알림 연관 기능 수정

### DIFF
--- a/src/main/java/org/example/tokpik_be/notification/domain/Notification.java
+++ b/src/main/java/org/example/tokpik_be/notification/domain/Notification.java
@@ -32,6 +32,9 @@ public class Notification extends BaseTimeEntity {
     private Long id;
 
     @Column(nullable = false)
+    private String name;
+
+    @Column(nullable = false)
     private LocalDate noticeDate;
 
     @Column(nullable = false)
@@ -55,12 +58,14 @@ public class Notification extends BaseTimeEntity {
     @JoinColumn(name = "notification_id")
     private List<NotificationTalkTopic> notificationTalkTopics = new ArrayList<>();
 
-    public Notification(LocalDate noticeDate,
+    public Notification(String name,
+        LocalDate noticeDate,
         LocalTime startTime,
         LocalTime endTime,
         int intervalMinutes,
         User user,
         Scrap scrap) {
+        this.name = name;
         this.noticeDate = noticeDate;
         this.startTime = startTime;
         this.endTime = endTime;

--- a/src/main/java/org/example/tokpik_be/notification/dto/request/NotificationCreateRequest.java
+++ b/src/main/java/org/example/tokpik_be/notification/dto/request/NotificationCreateRequest.java
@@ -1,6 +1,7 @@
 package org.example.tokpik_be.notification.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 import java.time.LocalDate;
@@ -8,6 +9,10 @@ import java.time.LocalTime;
 import java.util.List;
 
 public record NotificationCreateRequest(
+    @Schema(type = "string", description = "알림 이름", example = "알림 이름")
+    @NotBlank(message = "알림 이름은 필수값")
+    String notificationName,
+
     @Schema(type = "number", description = "스크랩 ID", example = "1")
     long scrapId,
 

--- a/src/main/java/org/example/tokpik_be/notification/dto/response/NotificationScheduledResponse.java
+++ b/src/main/java/org/example/tokpik_be/notification/dto/response/NotificationScheduledResponse.java
@@ -3,6 +3,8 @@ package org.example.tokpik_be.notification.dto.response;
 import java.time.LocalTime;
 
 public record NotificationScheduledResponse(
+    long notificationId,
+    long notificationTalkTopicId,
     String receiverToken,
     String talkTopicTitle,
     String talkTopicSubtitle,

--- a/src/main/java/org/example/tokpik_be/notification/dto/response/NotificationsResponse.java
+++ b/src/main/java/org/example/tokpik_be/notification/dto/response/NotificationsResponse.java
@@ -35,8 +35,8 @@ public record NotificationsResponse(
         @Schema(type = "number", description = "알림 간격(분 단위)", example = "30")
         int notificationInterval,
 
-        @Schema(type = "string", description = "스크랩 이름", example = "부장님 개그 모음")
-        String scrapName,
+        @Schema(type = "string", description = "알림 이름", example = "부장님 개그 모음")
+        String notificationName,
 
         @Schema(type = "number", description = "스크랩에 저장된 대화 주제 합계", example = "30")
         long notificationTopicTotal,

--- a/src/main/java/org/example/tokpik_be/notification/repository/QueryDslNotificationRepository.java
+++ b/src/main/java/org/example/tokpik_be/notification/repository/QueryDslNotificationRepository.java
@@ -124,6 +124,8 @@ public class QueryDslNotificationRepository {
 
         return queryFactory.from(notification)
             .select(Projections.constructor(NotificationScheduledResponse.class,
+                notification.id,
+                notificationTalkTopic.id,
                 user.notificationToken,
                 talkTopic.title,
                 talkTopic.subtitle,
@@ -133,9 +135,11 @@ public class QueryDslNotificationRepository {
             .join(notification.notificationTalkTopics, notificationTalkTopic)
             .join(notificationTalkTopic.talkTopic, talkTopic)
             .join(notification.user, user)
-            .where(notification.deleted.isFalse().and(notification.noticeDate.eq(sendDate)
-                .and(notification.startTime.loe(sendTime))
-                .and(notification.endTime.goe(sendTime))))
+            .where(user.notificationToken.isNotNull()
+                .and(notification.deleted.isFalse())
+                .and(notification.noticeDate.eq(sendDate)
+                    .and(notification.startTime.loe(sendTime))
+                    .and(notification.endTime.goe(sendTime))))
             .fetch();
     }
 }

--- a/src/main/java/org/example/tokpik_be/notification/repository/QueryDslNotificationRepository.java
+++ b/src/main/java/org/example/tokpik_be/notification/repository/QueryDslNotificationRepository.java
@@ -2,7 +2,6 @@ package org.example.tokpik_be.notification.repository;
 
 import static org.example.tokpik_be.notification.domain.QNotification.notification;
 import static org.example.tokpik_be.notification.domain.QNotificationTalkTopic.notificationTalkTopic;
-import static org.example.tokpik_be.scrap.domain.QScrap.scrap;
 import static org.example.tokpik_be.tag.domain.QTopicTag.topicTag;
 import static org.example.tokpik_be.talk_topic.domain.QTalkTopic.talkTopic;
 import static org.example.tokpik_be.user.domain.QUser.user;
@@ -65,16 +64,15 @@ public class QueryDslNotificationRepository {
         // 알림과 알림 포함된 대화 주제들의 대화 종류 데이터 조회
         List<Tuple> results = queryFactory.from(notification)
             .select(notification.id,
+                notification.name,
                 notification.noticeDate,
                 notification.startTime,
                 notification.endTime,
                 notification.intervalMinutes,
                 notificationTalkTopic.id,
-                scrap.title,
                 topicTag.id,
                 topicTag.content)
             .join(notification.notificationTalkTopics, notificationTalkTopic)
-            .join(notification.scrap, scrap)
             .join(notificationTalkTopic.talkTopic, talkTopic)
             .join(talkTopic.topicTag, topicTag)
             .where(usersNotificationCondition.and(notification.id.in(notificationIds)))
@@ -109,7 +107,7 @@ public class QueryDslNotificationRepository {
                     tuple.get(notification.startTime),
                     tuple.get(notification.endTime),
                     tuple.get(notification.intervalMinutes),
-                    tuple.get(scrap.title),
+                    tuple.get(notification.name),
                     notificationTopicTotal,
                     talkTopicTypeResponses);
             })

--- a/src/main/java/org/example/tokpik_be/notification/service/NotificationCommandService.java
+++ b/src/main/java/org/example/tokpik_be/notification/service/NotificationCommandService.java
@@ -81,7 +81,8 @@ public class NotificationCommandService {
         }
 
         // 알림 생성 및 저장
-        Notification notification = new Notification(request.noticeDate(),
+        Notification notification = new Notification(request.notificationName(),
+            request.noticeDate(),
             request.notificationStartTime(),
             request.notificationEndTime(),
             intervalMinutes,

--- a/src/main/java/org/example/tokpik_be/notification/service/NotificationQueryService.java
+++ b/src/main/java/org/example/tokpik_be/notification/service/NotificationQueryService.java
@@ -1,10 +1,14 @@
 package org.example.tokpik_be.notification.service;
 
+import static java.util.Comparator.comparing;
+
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -44,6 +48,13 @@ public class NotificationQueryService {
         return queryDslNotificationRepository.getNotifications(userId, nextCursorId, pageSize);
     }
 
+    /**
+     * 1분마다 알림 송신을 수행하는 스케줄러, 이하 과정에 따라 작업 수행 <br/> <br/>
+     * 1. 현재 일시가 알림 시작 시간/종료 시간에 포함되는 알림들 조회 <br/>
+     * 2. 조회된 알림들을 알림 간격(분 단위)에 따라 grouping <br/>
+     * 3. 조회된 알림들 중 알림 지정 순서에 따라 최종적으로 송신될 알림 필터링 <br/>
+     * 4. 알림 송신 이벤트 publish
+     */
     @Async
     @Scheduled(fixedRate = 1000 * 60)
     public void sendScheduledNotifications() {
@@ -51,40 +62,113 @@ public class NotificationQueryService {
 
         List<NotificationScheduledResponse> scheduledNotifications = queryDslNotificationRepository
             .getScheduledNotifications(now);
-
-        // 분 간격에 따라 알림 grouping
         Map<Integer, List<NotificationScheduledResponse>> groupByInterval = scheduledNotifications
             .stream()
             .collect(Collectors.groupingBy(NotificationScheduledResponse::intervalMinutes));
 
         LocalTime noticeTime = now.toLocalTime();
-        for (int interval : groupByInterval.keySet()) {
-            List<NotificationScheduledResponse> notifications = groupByInterval.get(interval);
+        List<NotificationSendEvent> events = groupByInterval.entrySet().stream()
+            .flatMap(entry -> filterNotificationToSend(entry.getValue(), noticeTime).stream())
+            .toList();
 
-            if (notifications.isEmpty()) {
-                continue;
-            }
-
-            // 현재 일시가 알림 일시인 경우 필터링
-            List<NotificationScheduledResponse> sendNotifications = notifications.stream()
-                .filter(notification -> isNoticeTime(notification, noticeTime))
-                .toList();
-
-            // 알림 이벤트 publishing
-            sendNotifications
-                .stream()
-                .map(notification -> new NotificationSendEvent(notification.receiverToken(),
-                    notification.talkTopicTitle(),
-                    notification.talkTopicSubtitle()))
-                .forEach(eventPublisher::publishEvent);
-        }
+        events.forEach(eventPublisher::publishEvent);
     }
 
+    /**
+     * 최종적으로 송신할 알림들을 필터링하는 로직, 이하 과정 수행 <br/>
+     * 1. 현재 시간이 송신할 시간인 알림들 필터링 <br/>
+     * 2. 알림 ID에 따라 알림들 grouping <br/>
+     * 3. 알림 지정 순서(알림 대화 주제 ID)에 따라 그룹별 알림들 정렬 <br/>
+     * 4. 송신 일시에 해당하는 알림들 내에서, 알림 지정 순서에 따라 송신할 알림들 선택
+     *
+     * @param notifications 시작 시간 ~ 종료 시간 내에 알림(송신) 일시가 포함되는 알림 목록
+     * @param noticeTime    알림 일시(송신 일시)
+     * @return 송신할 알림 목록, 알림 송신 이벤트로 변환하여 제공
+     */
+    private List<NotificationSendEvent> filterNotificationToSend(
+        List<NotificationScheduledResponse> notifications,
+        LocalTime noticeTime) {
+        Map<Long, List<NotificationScheduledResponse>> groupByNotificationId = notifications.stream()
+            .filter(notification -> isNoticeTime(notification, noticeTime))
+            .collect(Collectors.groupingBy(NotificationScheduledResponse::notificationId));
+
+        groupByNotificationId.forEach((notificationId, group) ->
+            group.sort(comparing(NotificationScheduledResponse::notificationTalkTopicId)));
+
+        return groupByNotificationId.values().stream()
+            .map(group -> selectNotificationToSend(group, noticeTime))
+            .filter(Objects::nonNull)
+            .toList();
+    }
+
+    /**
+     * 특정 알림과 연관된 DTO 그룹에서 알림 지정 순서에 따라 현재 송신할 알림을 선택하는 로직
+     *
+     * @param group      특정 알림과 관련된 DTO 그룹
+     * @param noticeTime 알림 일시(송신 일시)
+     * @return 송신할 알림 정보, 알림 송신 이벤트로 변환하여 제공
+     */
+    private NotificationSendEvent selectNotificationToSend(
+        List<NotificationScheduledResponse> group,
+        LocalTime noticeTime) {
+
+        if (group.isEmpty()) {
+
+            return null;
+        }
+
+        NotificationScheduledResponse firstNotification = group.get(0);
+        List<LocalTime> timeIntervals = generateTimeIntervals(firstNotification.startTime(),
+            firstNotification.endTime(),
+            firstNotification.intervalMinutes());
+
+        int timeIndex = timeIntervals.indexOf(noticeTime);
+        if (timeIndex == -1) {
+
+            return null;
+        }
+
+        int notificationIndex = timeIndex % group.size();
+        NotificationScheduledResponse sendNotification = group.get(notificationIndex);
+
+        return new NotificationSendEvent(sendNotification.receiverToken(),
+            sendNotification.talkTopicTitle(),
+            sendNotification.talkTopicSubtitle());
+    }
+
+    /**
+     * 송신 알림 여부 확인 로직 <br/>
+     * 시작 시간부터 분 간격에 따라 알림 시간대를 구했을 때 송신 일시에 해당하는 것이 있는 경우 true 반환
+     *
+     * @param notification 알림
+     * @param noticeTime   알림 일시(송신 일시)
+     * @return 알림 일시(송신 일시) 해당 여부
+     */
     private boolean isNoticeTime(NotificationScheduledResponse notification, LocalTime noticeTime) {
         LocalTime startTime = notification.startTime();
         int intervalMinutes = notification.intervalMinutes();
         long minutesSinceStart = ChronoUnit.MINUTES.between(startTime, noticeTime);
 
         return minutesSinceStart % intervalMinutes == 0;
+    }
+
+    /**
+     * 분 간격에 따라 나눠진 시간 목록을 제공하는 로직
+     *
+     * @param from            시작 시간
+     * @param to              종료 시간
+     * @param intervalMinutes 분 간격
+     * @return 분 간격에 따라 시작 시간 ~ 종료 시간내 나눠진 시간 목록
+     */
+    private List<LocalTime> generateTimeIntervals(LocalTime from, LocalTime to,
+        int intervalMinutes) {
+        List<LocalTime> timeIntervals = new ArrayList<>();
+
+        while (from.isBefore(to)) {
+            timeIntervals.add(from);
+            from = from.plusMinutes(intervalMinutes);
+        }
+
+        return timeIntervals;
     }
 }


### PR DESCRIPTION
## 작업 대상
<!-- 작업 대상을 설명 -->
- 알림 생성
- 알림 목록 조회
- 알림 송신

## 📄 작업 내용
<!-- 작업한 내용을 간단히 요약해주세요. -->
### 알림 생성  / 알림 목록 조회
- 알림 생성 시 알림에 이름을 부여할 수 있음
- 알림 목록 조회 시 알림 이름 제공
위 두 요구사항 반영하여 연관 로직 수정

### 알림 송신
- 처음 알림 생성 시 대화 주제를 지정한 순서에 따라 차례에 맞게 알림을 송신해야 함
- 조회된 알림 송신 데이터를 알림 ID에 따라 grouping, 순서에 따라 적절한 알림을 선택하도록 알림 송신 로직 변경
- 복잡한 로직 단계별 메서드 분리. 코드 복잡성 감소, 결합도 향상


## 📎 레퍼런스
<!-- 작업 시 참고했던 문건의 URL을 남겨주세요 -->