### PR TITLE
스크랩 조회 시 커서 페이징에 사용되는 파라미터명 수정

### DIFF
--- a/src/main/java/org/example/tokpik_be/scrap/controller/ScrapController.java
+++ b/src/main/java/org/example/tokpik_be/scrap/controller/ScrapController.java
@@ -121,11 +121,11 @@ public class ScrapController {
     public ResponseEntity<ScrapResponse> getScrapTopics(
         @PathVariable @Parameter(description = "스크랩 ID") Long scrapId,
         @RequestParam(defaultValue = "0")
-        @Parameter(description = "마지막 스크랩된 주제 ID, 커서 페이징에 사용") Long lastCursorId,
+        @Parameter(description = "마지막 스크랩된 주제 ID, 커서 페이징에 사용") Long nextCursorId,
         @RequestParam(defaultValue = "10")
         @Parameter(description = "페이지 크기") int size
     ) {
-        ScrapResponse response = scrapService.getScrapTopics(scrapId, lastCursorId, size);
+        ScrapResponse response = scrapService.getScrapTopics(scrapId, nextCursorId, size);
         return ResponseEntity.ok(response);
     }
 

--- a/src/main/java/org/example/tokpik_be/scrap/dto/response/ScrapResponse.java
+++ b/src/main/java/org/example/tokpik_be/scrap/dto/response/ScrapResponse.java
@@ -10,7 +10,7 @@ public record ScrapResponse(
 
     @JsonProperty(required = true)
     @Schema(type = "number", description = "제공된 데이터 중 가장 마지막 데이터 ID", example = "4")
-    Long lastCursorId,
+    Long nextCursorId,
 
     @JsonProperty(required = true)
     @Schema(type = "boolean", description = "첫 페이지 여부", example = "true")

--- a/src/main/java/org/example/tokpik_be/scrap/service/ScrapService.java
+++ b/src/main/java/org/example/tokpik_be/scrap/service/ScrapService.java
@@ -135,21 +135,21 @@ public class ScrapService {
 
     }
 
-    public ScrapResponse getScrapTopics(Long scrapId, Long lastCursorId, int size) {
+    public ScrapResponse getScrapTopics(Long scrapId, Long nextCursorId, int size) {
 
         Scrap scrap = findById(scrapId);
 
-        if (lastCursorId != null && lastCursorId > 0) {
-            boolean isValidLastCursor = scrapTopicRepository.existsByScrapIdAndId(scrapId,
-                lastCursorId);
-            if (!isValidLastCursor) {
+        if (nextCursorId != null && nextCursorId > 0) {
+            boolean isValidNextCursor = scrapTopicRepository.existsByScrapIdAndId(scrapId,
+                nextCursorId);
+            if (!isValidNextCursor) {
                 throw new GeneralException(ScrapException.INVALID_SCRAP_TOPIC);
             }
         }
 
         Pageable pageable = PageRequest.of(0, size);
         List<ScrapTopic> scrapTopics = scrapTopicRepository
-            .findByScrapIdAndIdGreaterThanOrderByIdAsc(scrapId, lastCursorId, pageable);
+            .findByScrapIdAndIdGreaterThanOrderByIdAsc(scrapId, nextCursorId, pageable);
 
         List<ScrapResponse.ScrapTopicResponse> contents = scrapTopics.stream()
             .map(scrapTopic -> {
@@ -165,23 +165,23 @@ public class ScrapService {
             })
             .toList();
 
-        Long newLastCursorId = contents.isEmpty() ? lastCursorId :
+        Long newNextCursorId = contents.isEmpty() ? nextCursorId :
             scrapTopics.get(scrapTopics.size() - 1).getId();
 
         boolean isFirst;
-        if (lastCursorId == null || lastCursorId == 0) {
+        if (nextCursorId == null || nextCursorId == 0) {
             isFirst = true;
         } else {
-            long countAfterLastCursor = scrapTopicRepository
-                .countByScrapIdAndIdGreaterThan(scrapId, lastCursorId);
-            isFirst = countAfterLastCursor == 0;
+            long countAfterNextCursor = scrapTopicRepository
+                .countByScrapIdAndIdGreaterThan(scrapId, nextCursorId);
+            isFirst = countAfterNextCursor == 0;
         }
 
         boolean isLast = scrapTopics.size() < size;
 
         return new ScrapResponse(
             contents,
-            newLastCursorId,
+            newNextCursorId,
             isFirst,
             isLast
         );


### PR DESCRIPTION
## 작업 대상
<!-- 작업 대상을 설명 -->
- 스크랩 조회 요청 파라미터명 변경

## 📄 작업 내용
<!-- 작업한 내용을 간단히 요약해주세요. -->
- 다른 API와 요청 통일성을 위해 커서 페이징 시 사용되는 파라미터명을 nextCursorId로 변경

## 📎 레퍼런스
<!-- 작업 시 참고했던 문건의 URL을 남겨주세요 -->