### PR TITLE
로그인 기능 수정

### DIFF
--- a/src/main/java/org/example/tokpik_be/login/controller/LoginController.java
+++ b/src/main/java/org/example/tokpik_be/login/controller/LoginController.java
@@ -5,18 +5,14 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.example.tokpik_be.exception.GeneralException;
-import org.example.tokpik_be.exception.LoginException;
 import org.example.tokpik_be.login.dto.request.AccessTokenRefreshRequest;
+import org.example.tokpik_be.login.dto.request.LoginByKakaoRequest;
 import org.example.tokpik_be.login.dto.response.AccessTokenRefreshResponse;
 import org.example.tokpik_be.login.dto.response.LoginResponse;
 import org.example.tokpik_be.login.service.LoginCommandService;
 import org.springframework.http.ResponseEntity;
-import org.springframework.util.StringUtils;
-import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @Tag(name = "Login API", description = "로그인 관련 API")
@@ -26,16 +22,13 @@ public class LoginController {
 
     private final LoginCommandService loginCommandService;
 
-    @GetMapping("/oauth/kakao")
+    @Operation(summary = "카카오 소셜 로그인", description = "카카오 인카 코드 바탕 소셜 로그인 수행")
+    @ApiResponse(responseCode = "200", description = "카카오 소셜 로그인 성공")
+    @PostMapping("/login/kakao")
     public ResponseEntity<LoginResponse> kakaoLogin(
-        @RequestParam("code") String code,
-        @RequestParam(name = "error", required = false) String error) {
+        @RequestBody @Valid LoginByKakaoRequest request) {
 
-        if (StringUtils.hasText(error)) {
-            throw new GeneralException(LoginException.LOGIN_FAIL);
-        }
-
-        LoginResponse response = loginCommandService.kakaoLogin(code);
+        LoginResponse response = loginCommandService.kakaoLogin(request);
 
         return ResponseEntity.ok().body(response);
     }

--- a/src/main/java/org/example/tokpik_be/login/dto/request/LoginByKakaoRequest.java
+++ b/src/main/java/org/example/tokpik_be/login/dto/request/LoginByKakaoRequest.java
@@ -1,0 +1,12 @@
+package org.example.tokpik_be.login.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+
+public record LoginByKakaoRequest(
+    @Schema(type = "string", description = "카카오 서버로부터 받은 인가 코드", example = "code")
+    @NotBlank(message = "인가 코드는 필수 값")
+    String code
+) {
+
+}

--- a/src/main/java/org/example/tokpik_be/login/service/LoginCommandService.java
+++ b/src/main/java/org/example/tokpik_be/login/service/LoginCommandService.java
@@ -5,6 +5,7 @@ import lombok.RequiredArgsConstructor;
 import org.example.tokpik_be.exception.GeneralException;
 import org.example.tokpik_be.exception.LoginException;
 import org.example.tokpik_be.login.dto.request.AccessTokenRefreshRequest;
+import org.example.tokpik_be.login.dto.request.LoginByKakaoRequest;
 import org.example.tokpik_be.login.dto.response.AccessTokenRefreshResponse;
 import org.example.tokpik_be.login.dto.response.KakaoUserResponse;
 import org.example.tokpik_be.login.dto.response.LoginResponse;
@@ -25,9 +26,9 @@ public class LoginCommandService {
     private final KakaoApiClient kakaoApiClient;
     private final JwtUtil jwtUtil;
 
-    public LoginResponse kakaoLogin(String code) {
+    public LoginResponse kakaoLogin(LoginByKakaoRequest request) {
 
-        KakaoUserResponse kakaoUserResponse = kakaoApiClient.requestKakaoUser(code);
+        KakaoUserResponse kakaoUserResponse = kakaoApiClient.requestKakaoUser(request.code());
         String email = kakaoUserResponse.email();
 
         if (userQueryService.notExistByEmail(email)) {


### PR DESCRIPTION
## 작업 대상
<!-- 작업 대상을 설명 -->
- 로그인

## 📄 작업 내용
<!-- 작업한 내용을 간단히 요약해주세요. -->
- 기존 로그인은 OAuth 서버로부터의 인가 코드 콜백을 백엔드에서 받는 식으로 구성되어 있음
- 하지만 해당 플로우의 경우 프론트에서 인증 과정 결과로 제공되는 응답에 접근할 수 없음
- 인가 코드 콜백을 프론트에서 받고 이를 백엔드로 전달하여 로그인을 진행하는 플로우로 API, 비즈니스 로직 재구성

## 📎 레퍼런스
<!-- 작업 시 참고했던 문건의 URL을 남겨주세요 -->