### PR TITLE
연관 대화 주제 조회 - 캐싱 도입

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,6 +34,8 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-webflux'
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+    implementation 'org.springframework.boot:spring-boot-starter-cache'
 
     // swagger
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2'

--- a/src/main/java/org/example/tokpik_be/config/CacheConfig.java
+++ b/src/main/java/org/example/tokpik_be/config/CacheConfig.java
@@ -1,0 +1,31 @@
+package org.example.tokpik_be.config;
+
+import java.time.Duration;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializationContext.SerializationPair;
+
+@Configuration
+@EnableCaching
+public class CacheConfig {
+
+    @Bean
+    public CacheManager cacheManager(RedisConnectionFactory redisConnectionFactory) {
+        RedisCacheConfiguration cacheConfiguration = RedisCacheConfiguration
+            .defaultCacheConfig()
+            .entryTtl(Duration.ofMinutes(60))
+            .disableCachingNullValues()
+            .serializeValuesWith(SerializationPair
+                .fromSerializer(new GenericJackson2JsonRedisSerializer()));
+
+        return RedisCacheManager.builder(redisConnectionFactory)
+            .cacheDefaults(cacheConfiguration)
+            .build();
+    }
+}

--- a/src/main/java/org/example/tokpik_be/talk_topic/service/TalkTopicQueryService.java
+++ b/src/main/java/org/example/tokpik_be/talk_topic/service/TalkTopicQueryService.java
@@ -16,6 +16,7 @@ import org.example.tokpik_be.user.service.UserQueryService;
 import org.example.tokpik_be.util.llm.client.LLMApiClient;
 import org.example.tokpik_be.util.llm.dto.request.LLMTalkTopicDetailRequest;
 import org.example.tokpik_be.util.llm.dto.response.LLMTalkTopicDetailResponse;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -37,6 +38,7 @@ public class TalkTopicQueryService {
             .orElseThrow(() -> new GeneralException(TalkTopicException.TALK_TOPIC_NOT_FOUND));
     }
 
+    @Cacheable(value = "relatedTalkTopics", key = "#topicId")
     public TalkTopicsRelatedResponse getRelatedTopics(long userId, long topicId) {
         User user = userQueryService.findById(userId);
         TalkTopic baseTopic = findById(topicId);

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -13,7 +13,16 @@ spring:
   jpa:
     hibernate:
       ddl-auto: none
+    properties:
+      hibernate:
+        show_sql: true
+        format_sql: true
 
   ai:
     openai:
       api-key: ${OPEN_AI_API_KEY}
+
+  data:
+    redis:
+      host: ${REDIS_HOST}
+      port: ${REDIS_PORT}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -13,10 +13,6 @@ spring:
   jpa:
     hibernate:
       ddl-auto: none
-    properties:
-      hibernate:
-        show_sql: true
-        format_sql: true
 
   ai:
     openai:


### PR DESCRIPTION
## 작업 대상
<!-- 작업 대상을 설명 -->
- 연관 대화 주제 조회 기능

## 📄 작업 내용
<!-- 작업한 내용을 간단히 요약해주세요. -->
- 연관 대화 주제 조회의 경우 동일한 데이터를 반복적으로 제공하여 높은 읽기 빈도 발생
- 한 번에 많은 요청이 몰릴 경우 응답 시간 지연, DB 부하 집중
- 성능 개선을 위해 Redis 이용, Look Aside + Write Around 캐싱 전략 도입
- 응답 시간 향상, DB 부하 개선

## 📎 레퍼런스
<!-- 작업 시 참고했던 문건의 URL을 남겨주세요 -->