### PR TITLE
카카오 소셜 로그인 기능 수정

### DIFF
--- a/src/main/java/org/example/tokpik_be/login/service/KakaoApiClient.java
+++ b/src/main/java/org/example/tokpik_be/login/service/KakaoApiClient.java
@@ -1,35 +1,43 @@
 package org.example.tokpik_be.login.service;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import java.io.IOException;
-import java.util.Base64;
 import java.util.Map;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
-import org.example.tokpik_be.exception.GeneralException;
-import org.example.tokpik_be.exception.LoginException;
+import lombok.extern.slf4j.Slf4j;
 import org.example.tokpik_be.login.dto.response.KakaoUserResponse;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpHeaders;
-import org.springframework.http.HttpStatusCode;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Component;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.reactive.function.BodyInserters;
 import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
 import reactor.core.publisher.Mono;
 
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class KakaoApiClient {
 
-    private final ObjectMapper objectMapper;
     @Value("${KAKAO_API_CLIENT_ID}")
     private String clientId;
     @Value("${KAKAO_LOGIN_REDIRECT_URL}")
     private String redirectUrl;
 
+    private final String contentType = MediaType.APPLICATION_FORM_URLENCODED_VALUE
+        .concat(";charset=utf-8");
+
     public KakaoUserResponse requestKakaoUser(String code) {
+        String accessToken = getAccessToken(code);
+
+        return getKakaoUser(accessToken);
+    }
+
+    private String getAccessToken(String code) {
         WebClient webClient = WebClient.builder()
             .baseUrl("https://kauth.kakao.com/oauth/token")
             .build();
@@ -40,38 +48,57 @@ public class KakaoApiClient {
         loginRequest.add("redirect_uri", redirectUrl);
         loginRequest.add("code", code);
 
-        try {
-            Map<String, String> response = webClient.post()
-                .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_FORM_URLENCODED_VALUE)
-                .body(BodyInserters.fromFormData(loginRequest))
-                .retrieve()
-                .onStatus(HttpStatusCode::is4xxClientError,
-                    apiResponse -> Mono.error(new GeneralException(LoginException.LOGIN_FAIL)))
-                .bodyToMono(Map.class)
-                .block();
+        Map<String, String> response = webClient.post()
+            .header(HttpHeaders.CONTENT_TYPE, contentType)
+            .body(BodyInserters.fromFormData(loginRequest))
+            .retrieve()
+            .bodyToMono(Map.class)
+            .onErrorResume(WebClientResponseException.class, ex -> {
+                Map<String, String> errorBody;
 
-            return toKakaoLoginResponse(response);
-        } catch (GeneralException e) {
-            throw e;
-        }
+                try {
+                    errorBody = new ObjectMapper().readValue(ex.getResponseBodyAsString(),
+                        Map.class);
+                    log.error("API Error : code : {}, error : {}, description : {}",
+                        ex.getStatusCode(),
+                        errorBody.get("error"),
+                        errorBody.get("error_description")
+                    );
+                } catch (JsonProcessingException e) {
+                    log.error("error parsing error response", e);
+                }
+
+                return Mono.error(ex);
+            })
+            .block();
+
+        return Optional.ofNullable(response.get("access_token"))
+            .orElseThrow(() -> new IllegalStateException("error occur when get access token"));
     }
 
-    private KakaoUserResponse toKakaoLoginResponse(Map<String, String> response) {
+    private KakaoUserResponse getKakaoUser(String accessToken) {
+        WebClient webClient = WebClient.builder()
+            .baseUrl("https://kapi.kakao.com/v2/user/me")
+            .build();
 
-        String idToken = response.get("id_token");
-        String payload = idToken.split("\\.")[1];
+        String bearerToken = "Bearer ".concat(accessToken);
 
-        byte[] decodedPayload = Base64.getUrlDecoder().decode(payload);
+        Map<String, Object> response = webClient.post()
+            .header(HttpHeaders.AUTHORIZATION, bearerToken)
+            .header(HttpHeaders.CONTENT_TYPE, contentType)
+            .retrieve()
+            .bodyToMono(Map.class)
+            .block();
 
-        try {
-            Map<String, String> loginResponse = objectMapper.readValue(decodedPayload, Map.class);
-            String email = loginResponse.get("email");
-            String profilePhotoUrl = loginResponse.get("picture");
+        Map<String, Object> kakaoAccount = (Map<String, Object>) response.get("kakao_account");
+        String email = Optional.ofNullable(kakaoAccount.get("email"))
+            .map(String::valueOf)
+            .orElseThrow(() -> new IllegalStateException("error occur when get email"));
+        Map<String, String> profile = (Map<String, String>) kakaoAccount.get("profile");
+        String profileImageUrl = Optional.ofNullable(profile.get("profile_image_url"))
+            .map(String::valueOf)
+            .orElseThrow(() -> new IllegalStateException("error occur when get profile_image_url"));
 
-            return new KakaoUserResponse(email, profilePhotoUrl);
-
-        } catch (IOException e) {
-            throw new IllegalStateException("카카오 id_token 파싱 중 예외 발생");
-        }
+        return new KakaoUserResponse(email, profileImageUrl);
     }
 }


### PR DESCRIPTION

## 작업 대상
<!-- 작업 대상을 설명 -->
- 카카오 소셜 로그인 기능

## 📄 작업 내용
<!-- 작업한 내용을 간단히 요약해주세요. -->
- 기존 코드는 token 발급 시 제공되는 id_token을 통해 사용자 정보 획득
- 하지만 해당 플로우로 인증 진행 시 중복 인가 코드 에러 발생
- 카카오 공식 문서에서 언급된 사용자 정보 획득 API로 정보를 얻도록 로직 수정

## 📎 레퍼런스
<!-- 작업 시 참고했던 문건의 URL을 남겨주세요 -->